### PR TITLE
Fix wonky jump controls

### DIFF
--- a/game.js
+++ b/game.js
@@ -309,7 +309,7 @@ function moveEntityVert(e, vy, checkPlatform) {
   const left  = Math.floor(e.x / TS);
   const right = Math.floor((e.x + e.w - 1) / TS);
   const top   = Math.floor(e.y / TS);
-  const bot   = Math.floor((e.y + e.h - 1) / TS);
+  const bot   = Math.floor((e.y + e.h) / TS);
   e.onGround = false;
   if (vy > 0) {
     for (let tx = left; tx <= right; tx++) {
@@ -318,7 +318,7 @@ function moveEntityVert(e, vy, checkPlatform) {
         e.onGround = true;
         return true;
       }
-      if (checkPlatform && isPlatform(tx, bot) && Math.floor((e.y + e.h - vy - 1) / TS) < bot) {
+      if (checkPlatform && isPlatform(tx, bot) && Math.floor((e.y + e.h - vy) / TS) < bot) {
         e.y = bot * TS - e.h;
         e.onGround = true;
         return true;
@@ -388,6 +388,7 @@ function makePlayer() {
     facing: 1,
     pogoing: false,
     jumpHeld: false,
+    jumpBuffer: 0,
     lives: 3,
     score: 0,
     health: 3,
@@ -422,10 +423,12 @@ function updatePlayer() {
   }
 
   // Jump / Pogo
-  const jumpJustPressed = isJump() && !wasJump();
+  if (isJump() && !wasJump()) player.jumpBuffer = 8; // buffer press for 8 frames
+  if (player.jumpBuffer > 0) player.jumpBuffer--;
   player.pogoing = false;
 
-  if (jumpJustPressed && player.onGround) {
+  if (player.jumpBuffer > 0 && player.onGround) {
+    player.jumpBuffer = 0;
     if (isDown()) {
       // Trekking pole pogo
       player.vy = POGO_FORCE;
@@ -437,10 +440,12 @@ function updatePlayer() {
     }
   }
 
-  // Variable jump height
+  // Variable jump height: cut upward speed when button released early
   if (player.jumpHeld) {
-    if (!isJump()) { player.jumpHeld = false; }
-    else if (player.vy < -6) { player.vy += 0.4; } // cut short if button released
+    if (!isJump()) {
+      player.jumpHeld = false;
+      if (player.vy < -5) player.vy = -5;
+    }
   }
 
   // Bear spray


### PR DESCRIPTION
## Summary

- **Ground detection flicker** — `onGround` was alternating true/false every other frame because gravity (0.55 px/frame) wasn't enough to cross the tile boundary with the old `e.y + e.h - 1` calculation. Changed to `e.y + e.h` so the ground tile is reliably detected every frame.
- **Jump input buffering** — added an 8-frame buffer so pressing Space/Z just before landing queues the jump rather than silently dropping it.
- **Variable jump height (inverted bug)** — the old code was dampening the jump while the button was *held*. Fixed to cut upward velocity when the button is *released* early (tap = short hop, hold = full jump).

## Test plan

- [ ] Press Space/Z while standing — jumps every time, no missed presses
- [ ] Tap jump just before landing — buffers and fires on touchdown
- [ ] Short-tap vs hold jump — noticeably different heights
- [ ] Down + Jump pogo still works
- [ ] Enemies still land on platforms correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)