### PR TITLE
Fix leaderboard extending past bottom of canvas

### DIFF
--- a/game.js
+++ b/game.js
@@ -1900,15 +1900,15 @@ function drawMenu() {
   if (leaderboardLoaded && leaderboard.length > 0) {
     ctx.fillStyle = '#FFD700';
     ctx.font = 'bold 14px Courier New';
-    ctx.fillText('TOP  TRAIL  BLAZERS', W / 2, 320);
+    ctx.fillText('TOP  TRAIL  BLAZERS', W / 2, 310);
 
-    ctx.font = '13px Courier New';
+    ctx.font = '12px Courier New';
     leaderboard.forEach((entry, i) => {
       const rank = (i + 1).toString().padStart(2, ' ');
       const name = (entry.name || '???').padEnd(3, ' ');
       const score = entry.score.toString().padStart(7, ' ');
       ctx.fillStyle = i === 0 ? '#FFD700' : (i < 3 ? '#C0C0C0' : '#8BC48B');
-      ctx.fillText(`${rank}. ${name}  ${score}`, W / 2, 342 + i * 17);
+      ctx.fillText(`${rank}. ${name}  ${score}`, W / 2, 326 + i * 14);
     });
   } else {
     // Show controls if no leaderboard yet


### PR DESCRIPTION
## Summary
- Fixed the leaderboard on the title screen overflowing past the bottom edge of the 480px canvas
- The 10-entry leaderboard previously started at y=342 with 17px spacing, placing the last entry at y=495 (15px past the canvas)
- Adjusted layout: moved header to y=310, reduced entry font to 12px with 14px line spacing, so all 10 entries fit (y=326..452) with room above the hi-score line at y=460

Fixes #15

## Test plan
- [ ] Load the game with a full 10-entry leaderboard and verify all entries are visible on screen
- [ ] Verify the hi-score line at the bottom does not overlap with leaderboard entries
- [ ] Check that leaderboard text remains readable at the slightly smaller font size

https://claude.ai/code/session_01G9N6P4LQxKYAmn7rcFxmgt