### PR TITLE
Fix leaderboard overflow — show all 10 entries on screen

### DIFF
--- a/game.js
+++ b/game.js
@@ -1963,7 +1963,7 @@ function drawMenu() {
   const showLeaderboard = hasLeaderboard && Math.floor(game.tick / ATTRACT_FLIP) % 2 === 1;
 
   // Panel header with indicator dots
-  const panelY = 272;
+  const panelY = 256;
   if (hasLeaderboard) {
     // Draw two dots indicating which panel is shown
     const dotY = panelY - 4;
@@ -1982,25 +1982,16 @@ function drawMenu() {
     ctx.fillText('TOP  TRAIL  BLAZERS', W / 2, panelY + 18);
 
     ctx.font = '12px Courier New';
-    const rowHeight = 18;
+    const rowHeight = 16;
     const firstRowY = panelY + 44;
-    const maxRows = Math.min(
-      leaderboard.length,
-      Math.max(1, Math.floor((H - firstRowY - 40) / rowHeight))
-    );
 
-    leaderboard.slice(0, maxRows).forEach((entry, i) => {
+    leaderboard.forEach((entry, i) => {
       const rank = (i + 1).toString().padStart(2, ' ');
       const name = (entry.name || '???').toUpperCase().slice(0, 8).padEnd(8, ' ');
       const score = entry.score.toString().padStart(7, ' ');
       ctx.fillStyle = i === 0 ? '#FFD700' : (i < 3 ? '#C0C0C0' : '#8BC48B');
       ctx.fillText(`${rank}. ${name} ${score}`, W / 2, firstRowY + i * rowHeight);
     });
-
-    if (leaderboard.length > maxRows) {
-      ctx.fillStyle = '#88DDFF';
-      ctx.fillText('... more top scores', W / 2, firstRowY + maxRows * rowHeight);
-    }
   } else {
     // Controls panel — always shown when leaderboard is absent, alternates when present
     ctx.fillStyle = '#FFD700';


### PR DESCRIPTION
## Summary

- Moves the attract panel up (`panelY` 272 → 256) to create vertical room
- Tightens row height from 18 → 16px so 10 entries span only 144px
- All 10 leaderboard entries now fit cleanly above the hi-score line (last entry at y=444, hi-score at y=460)
- Removes the truncation logic and `... more top scores` fallback that was the workaround

Closes #15

## Test plan
- [ ] With a leaderboard populated (10 entries), confirm all 10 names/scores are visible on the attract screen leaderboard panel
- [ ] Confirm last entry does not overlap the HI SCORE line at the bottom
- [ ] Confirm HOW TO PLAY panel still displays correctly at the same panelY

🤖 Generated with [Claude Code](https://claude.ai/claude-code)