### PR TITLE
Fix level 3 stuck enemies and inescapable gorge traps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,48 +18,101 @@ Then visit `http://localhost:3000`.
 
 | Key | Action |
 |-----|--------|
-| `←` `→` / `A` `D` | Move |
+| `←` `→` / `A` `D` | Move left/right |
 | `↑` / `W` / `Z` / `Space` | Jump (hold for higher jump) |
-| `↓` + Jump | **Trekking Pole Pogo** — super-high bounce |
-| `X` | **Bear Spray** — stuns nearby enemies |
+| `↓` + `←`/`→` | **Glissade** — sit-slide down hills to stun enemies (cooldown: 90 frames) |
+| `X` / `F` | **Bear Spray** — stuns nearby enemies (cooldown: 60 frames) |
+| `S` | Crouch / Glissade modifier |
 
-**Stomp mechanic:** jump on a stunned enemy to defeat it. Stomping an unstunned enemy stuns it first.
+**Combat:** Stomp on stunned enemies by jumping on them to defeat and score. On-screen buttons available on mobile devices.
 
 ## Objective
 
-Make it from the trailhead to the **summit flag** at the far right. Collect ultralight gear along the way to build your score.
+Navigate from the **trailhead to the summit flag** at the far right of each level. Progress through all 3 trails to reach the ultimate summit! 
+
+Collect ultralight gear along the way to build your score. Each trail remembers your score and lives as you advance. Two special achievements provide bonus points:
+
+- **Leave No Trace** (+1000 pts) — Collect every item on a trail
+- **Trail Angel** (+1500 pts) — Defeat every enemy on a trail
 
 ## Enemies
 
-| Enemy | Behavior |
-|-------|----------|
-| 🐿 Marmot | Patrols platforms, turns at ledges |
-| 🦟 Mosquito | Floats in a sine-wave pattern |
-| 🧳 Overloaded Hiker | Slow but wide, comically massive pack |
+| Enemy | Behavior | Points |
+|-------|----------|--------|
+| 🐿 Marmot | Patrols platforms, turns at ledges and walls | 100 |
+| 🐭 Micro Bear | Fast ground-dweller, speeds past platforms | 75 |
+| 🦟 Mosquito | Floats in a sine-wave pattern, reverses at walls | 150 |
+| 🧳 Overloaded Hiker | Heavy slow walker with a massive pack, patrols platforms | 300 |
+
+All enemies can be stunned with **Bear Spray** or by landing on them while jumping. Stomp stunned enemies to defeat them and score points.
 
 ## Collectibles
 
-| Item | Points |
-|------|--------|
-| Titanium Spork | 100 |
-| Protein Bar | 50 |
-| Water Filter | 200 |
-| Cuben Fiber Tent | 500 |
-| Bear Spray Refill | 150 |
+| Item | Points | Purpose |
+|------|--------|---------|
+| Titanium Spork | 100 | Ultralight utensil |
+| Protein Bar | 50 | Trail fuel |
+| Water Filter | 200 | Essential gear |
+| Cuben Fiber Tent | 500 | Shelter |
+| Bear Spray Refill | 150 | Combat consumable |
+
+Collect all items on a trail to earn the **Leave No Trace** award and a 1000-point bonus!
+
+## Scoring System
+
+- **Base score:** Collect items and defeat enemies
+- **High score tracking:** Persisted to browser `localStorage`
+- **Leaderboard:** Top 10 players (cloud-synced to Firebase)
+- **Initials entry:** When you break the top 10, enter your 3-letter name for the leaderboard
+- **Achievements:** Earn bonuses for exceptional play:
+  - **Leave No Trace:** Collect every item on a trail (+1000)
+  - **Trail Angel:** Defeat every enemy on a trail (+1500)
+
+## Mobile Support
+
+Trail Blazer is fully responsive and supports:
+- **Portrait mode:** On-screen touch buttons at the bottom (move left/right, jump, slide, spray)
+- **Landscape mode:** Full-screen canvas with semi-transparent overlay controls in corners
+- Optimized touch detection and button sizing for all screen sizes
+- Keyboard input on desktop
+
+## Progression
+
+Progress persists across levels:
+- Your score carries forward as you complete each trail
+- Your remaining lives carry forward (lose a life on any trail = restart that trail)
+- Achievements track which trails you've mastered
+- Game ends when you run out of lives
 
 ## Level Layout
 
-The trail runs through five sections:
+The game spans **3 complete trails**, each with multiple sections and escalating difficulty:
 
-1. **Meadow** — gentle hills, easy start
-2. **Forest** — log platforms through the tree canopy
-3. **Creek Crossing** — stepping stones over a water hazard
-4. **Rocky Slope** — ascending ledges
-5. **Alpine Approach** — exposed platforms to the summit
+### 1. **Meadow Trail** 
+Gentle rolling hills through wildflower meadows. Start your adventure here with platform jumping, basic enemy encounters, and introductory collectible challenges.
+
+### 2. **Pine Ridge**
+Dense forest adventure with treacherous ravines. Navigate through canopy platforms, cross water hazards via stepping stones, and face increasingly challenging enemy placements. The first ravine tests your glissade technique.
+
+### 3. **Alpine Pass**
+The final ascent above the treeline. Exposed platforms with sheer drops, boulder fields, switchback climbs, and exposed ridges. Culminates in a scree field push to the final summit flag.
+
+Each trail includes:
+- Solid terrain blocks and one-way platforms
+- Water hazards (instadeath if touched)
+- Enemy patrols with varied patterns
+- Scattered collectible gear
+- A summit flag marking the trail's end
 
 ## Tech
 
-- Pure HTML5 Canvas 2D — all rendering is canvas primitives, no images
-- Single `game.js` file (~700 lines), no build step
-- 60 fps game loop via `requestAnimationFrame`
-- Tile-based collision with one-way platforms
+- **Pure HTML5 Canvas 2D** — all rendering uses canvas primitives (ellipses, rects, paths, gradients), no sprite sheets or image assets
+- **No frameworks, no dependencies** — ~2350 lines of vanilla JavaScript, single `game.js` file, no build step
+- **Deterministic procedural generation** — background parallax layers use seeded PRNGs for consistent visuals
+- **Tile-based collision system** — 32px tile grid with tile types: solid, one-way platform, water, empty
+- **60 fps game loop** — `requestAnimationFrame` with fixed update and render stages
+- **Multi-level architecture** — Level definitions contain map builder, item spawns, enemy spawns, goal position
+- **Responsive canvas scaling** — Adapts to landscape mobile orientation while maintaining aspect ratio
+- **Touch event handling** — Custom touch binding system for mobile buttons, separate from keyboard input
+- **Leaderboard integration** — Firebase Firestore for top 10 score persistence and real-time sync
+- **Browser storage** — `localStorage` for high score and local leaderboard caching

--- a/game.js
+++ b/game.js
@@ -255,7 +255,7 @@ const LEVELS = [
       // ---- WATERFALL GORGE (x: 45-70) ----
       fill(47, 11, 68, 11, T_EMPTY);
       fill(47, 12, 68, 13, T_WATER);
-      hline(47, 48, 10, T_SOLID);
+      hline(47, 70, 10, T_SOLID); // rescue ledge: player can jump from y=14 floor to y=10, then escape up
       hline(50, 51, 8, T_SOLID);
       hline(53, 53, 6, T_PLATFORM);
       hline(55, 56, 9, T_SOLID);
@@ -263,7 +263,6 @@ const LEVELS = [
       hline(61, 61, 5, T_PLATFORM);
       hline(63, 64, 8, T_SOLID);
       hline(66, 67, 6, T_PLATFORM);
-      hline(69, 70, 10, T_SOLID);
 
       // ---- SWITCHBACK ASCENT (x: 70-105) ----
       fill(70, 9, 75, 10, T_SOLID);
@@ -281,6 +280,7 @@ const LEVELS = [
       // ---- EXPOSED RIDGE (x: 105-140) ----
       fill(105, 11, 138, 11, T_EMPTY);
       fill(105, 12, 138, 13, T_WATER);
+      hline(105, 138, 10, T_SOLID); // rescue ledge: player can jump from y=14 floor to y=10, then reach platforms above
       hline(105, 108, 8, T_PLATFORM);
       hline(110, 112, 6, T_PLATFORM);
       hline(114, 116, 8, T_PLATFORM);
@@ -325,7 +325,7 @@ const LEVELS = [
       return [
         makeMarmot(14, 10), makeMarmot(38, 7), makeMarmot(72, 8),
         makeMarmot(105, 10), makeMarmot(142, 8), makeMarmot(162, 8),
-        makeMouse(22, 10), makeMouse(55, 8), makeMouse(95, 10), makeMouse(140, 8),
+        makeMouse(21, 10), makeMouse(55, 8), makeMouse(99, 10), makeMouse(140, 8),
         makeMosquito(20, 6), makeMosquito(45, 5), makeMosquito(58, 4),
         makeMosquito(80, 4), makeMosquito(96, 3), makeMosquito(112, 4),
         makeMosquito(126, 3), makeMosquito(150, 4), makeMosquito(170, 3),


### PR DESCRIPTION
Closes #10
Also closes #18 (README update was bundled in the same commit)

## Summary

**Stuck micro bears (issue #10):**
- `makeMouse(22, 10)` was spawned inside `fill(22, 9, 25, 10, T_SOLID)` — moved to `(21, 10)`
- `makeMouse(95, 10)` was spawned inside `fill(94, 5, 98, 10, T_SOLID)` — moved to `(99, 10)`

**Inescapable gorge traps (issue #10):**

Both gorge sections (Waterfall Gorge x=47–70 and Exposed Ridge x=105–138) had water at y=12–13 and a solid floor at y=14. That's 6 tiles below the nearest platforms, but jump height is only ~4.4 tiles — so players who fell in were permanently stuck, taking continuous water damage with no escape.

Fix: added a continuous solid rescue ledge at **y=10** inside each gorge. Physics analysis:
- From y=14 floor → y=10 ledge = 4 tiles (128 px) — within the 142 px jump height ✓
- From y=10 ledge → y=6 platform = 4 tiles — also reachable ✓

Players who fall into the gorge now land on the y=10 ledge (no water damage there), and can jump back up to the stepping stones above.

**Also included:** README update improving controls documentation and objective description.

## Test plan
- [ ] Load level 3, verify no enemies are visually stuck in the ground at the start
- [ ] Navigate to the Waterfall Gorge (x≈47–70) and intentionally fall off a stepping stone — confirm you can jump to the y=10 ledge and escape
- [ ] Navigate to the Exposed Ridge (x≈105–138) and fall off a platform — confirm you can jump back up and are not stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)