### PR TITLE
Increase left/right button size by 20% in mobile landscape

### DIFF
--- a/style.css
+++ b/style.css
@@ -170,8 +170,8 @@ canvas {
     position: fixed;
     bottom: 8px;
     left: 8px;
-    width: clamp(90px, 18vw, 140px);
-    height: clamp(44px, 9vw, 65px);
+    width: clamp(108px, 21.6vw, 168px);
+    height: clamp(53px, 10.8vw, 78px);
     gap: 4px;
   }
   #touch-right {


### PR DESCRIPTION
## Summary
- Increases the `#touch-left` container dimensions by 20% in the landscape mobile media query
- Width: `clamp(90px, 18vw, 140px)` → `clamp(108px, 21.6vw, 168px)`
- Height: `clamp(44px, 9vw, 65px)` → `clamp(53px, 10.8vw, 78px)`

Closes #13

## Test plan
- Open the game on a mobile device (or emulated) in landscape orientation
- Verify the left/right directional buttons are visibly larger
- Verify other controls (SLIDE, SPRAY, JUMP) remain unchanged

https://claude.ai/code/session_01L9WDvACxcDP1Kj8KyGkNDn