### PR TITLE
Fix two inescapable switchback gaps in level 3

### DIFF
--- a/game.js
+++ b/game.js
@@ -276,6 +276,12 @@ const LEVELS = [
       fill(94, 5, 98, 10, T_SOLID);
       hline(97, 102, 3, T_PLATFORM);
       fill(100, 4, 104, 10, T_SOLID);
+      // Rescue platforms in the two inescapable 1-tile gaps:
+      // x=93 is boxed by fills at x=92 and x=94 with no landing spot above y=11 floor.
+      // x=99 is similarly boxed; nearest platform (y=3) is 8 tiles above — unreachable.
+      // A platform at y=7 in each gap is reachable from y=11 (4 tiles = 128px < 142px jump).
+      set(93, 7, T_PLATFORM);
+      set(99, 7, T_PLATFORM);
 
       // ---- EXPOSED RIDGE (x: 105-140) ----
       fill(105, 11, 138, 11, T_EMPTY);


### PR DESCRIPTION
Closes #10 (follow-up to #26)

## What was wrong

The switchback staircase in level 3 has 1-tile-wide gap columns at **x=93** and **x=99** between tall adjacent solid fills. Both gaps are completely boxed in horizontally — the solid fills on both sides prevent any lateral movement — so the player can only jump straight up. The problem: the nearest landable tiles are at y=4–6, which are 5–8 tiles above the y=11 floor. The player's max jump height is only ~4.4 tiles. Permanently stuck, must refresh.

These are at roughly 52% and 55% of the 180-tile level — exactly where the player reported the traps.

## Fix

Added a `T_PLATFORM` rescue tile at `y=7` in each gap column:

| Gap | From y=11 → y=7 | From y=7 → next platform |
|-----|-----------------|--------------------------|
| x=93 | 4 tiles = 128 px ✓ | `hline(91,96,4)` = 3 tiles ✓ |
| x=99 | 4 tiles = 128 px ✓ | `hline(97,102,3)` = 4 tiles ✓ |

Jump height = 142 px; all hops are within range.

## Note on prior PR #26

The water gorge rescue ledges from PR #26 (`hline(47,70,10)` and `hline(105,138,10)`) remain and address the water gorge trap (if you fall off a stepping stone into the gorge floor at y=14, you can now hop to y=10 and climb back up). Those are separate from the switchback gaps fixed here.

## Test plan
- [ ] In level 3, navigate to the switchback section (~50–58% of the level)
- [ ] Deliberately fall into the gap at x≈93 (between the 4th and 5th stair blocks) — confirm a small ledge at mid-height lets you escape
- [ ] Deliberately fall into the gap at x≈99 (between the 5th and 6th stair blocks) — confirm same
- [ ] Verify the rest of the switchback traversal still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)