### PR TITLE
Widen switchback pits to real hazards; fix unkillable mouse

### DIFF
--- a/game.js
+++ b/game.js
@@ -271,15 +271,17 @@ const LEVELS = [
       hline(79, 84, 6, T_PLATFORM);
       fill(82, 7, 86, 10, T_SOLID);
       hline(85, 90, 5, T_PLATFORM);
-      fill(88, 6, 92, 10, T_SOLID);
+      fill(88, 6, 91, 10, T_SOLID);   // trimmed right by 1 to widen pit 1
       hline(91, 96, 4, T_PLATFORM);
-      fill(94, 5, 98, 10, T_SOLID);
+      fill(95, 5, 97, 10, T_SOLID);   // trimmed both sides: pit 1 left wall at x=95, pit 2 right wall at x=97
       hline(97, 102, 3, T_PLATFORM);
-      fill(100, 4, 104, 10, T_SOLID);
-      // Rescue platforms in the two inescapable 1-tile gaps:
-      // x=93 is boxed by fills at x=92 and x=94 with no landing spot above y=11 floor.
-      // x=99 is similarly boxed; nearest platform (y=3) is 8 tiles above — unreachable.
-      // A platform at y=7 in each gap is reachable from y=11 (4 tiles = 128px < 142px jump).
+      fill(101, 4, 104, 10, T_SOLID); // trimmed left by 1 to widen pit 2
+      // Hazard pits with rescue platforms:
+      // Pit 1: x=92-94 (3 tiles wide) — water at bottom, rescue platform at x=93 y=7 (center)
+      // Pit 2: x=98-100 (3 tiles wide) — water at bottom, rescue platform at x=99 y=7 (center)
+      // Falling off-center = water damage; landing center = bounce out via platform (4 tiles up, within jump range)
+      fill(92, 9, 94, 10, T_WATER);
+      fill(98, 9, 100, 10, T_WATER);
       set(93, 7, T_PLATFORM);
       set(99, 7, T_PLATFORM);
 
@@ -331,7 +333,7 @@ const LEVELS = [
       return [
         makeMarmot(14, 10), makeMarmot(38, 7), makeMarmot(72, 8),
         makeMarmot(105, 10), makeMarmot(142, 8), makeMarmot(162, 8),
-        makeMouse(21, 10), makeMouse(55, 8), makeMouse(99, 10), makeMouse(140, 8),
+        makeMouse(21, 10), makeMouse(55, 8), makeMouse(72, 8), makeMouse(140, 8),
         makeMosquito(20, 6), makeMosquito(45, 5), makeMosquito(58, 4),
         makeMosquito(80, 4), makeMosquito(96, 3), makeMosquito(112, 4),
         makeMosquito(126, 3), makeMosquito(150, 4), makeMosquito(170, 3),


### PR DESCRIPTION
## Summary

- **Wider pits**: both switchback gaps (x=93, x=99) expanded from 1 tile to 3 tiles wide (x=92–94 and x=98–100) by trimming the adjacent stair fills
- **Water at the bottom**: `T_WATER` added at y=9–10 in both pits — falling off-center causes repeated damage
- **Rescue platforms preserved**: single-tile platforms remain centered (x=93 and x=99 at y=7), still reachable from the pit floor (4 tiles = 128px, within jump range ~142px) — skill floor, not a death trap
- **Unkillable mouse fixed**: relocated mouse from pit at (99,10) to stair surface (72,8), making Trail Angel bonus achievable again

The design intent: fall into the center → land on rescue platform, jump out. Fall off-center → land in water, take damage, must navigate back to center to escape.

## Test plan

- [ ] Play through Level 3 switchback section; verify both pits are visibly wider with water at the bottom
- [ ] Fall into a pit off-center — confirm water damage triggers
- [ ] Fall into a pit center — confirm rescue platform catches and is escapable
- [ ] Kill the mouse on the staircase at x=72 — confirm Trail Angel bonus unlocks after clearing all enemies

🤖 Generated with [Claude Code](https://claude.com/claude-code)