### PR TITLE
Fix mobile landscape layout issues

### DIFF
--- a/game.js
+++ b/game.js
@@ -17,9 +17,12 @@ function resizeCanvas() {
   const isTouch = matchMedia('(hover: none) and (pointer: coarse)').matches;
   const isLandscape = window.innerWidth > window.innerHeight;
   if (isTouch && isLandscape) {
-    const aspect = window.innerWidth / window.innerHeight;
-    H = 480;
-    W = Math.round(H * aspect);
+    // Use actual viewport height so the canvas doesn't overflow on devices where
+    // 100vh > physical screen height (e.g. iOS Safari in landscape). This also
+    // makes H < level height (480px), enabling vertical camera scrolling.
+    const vh = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+    H = Math.min(480, Math.round(vh));
+    W = Math.round(H * (window.innerWidth / vh));
   } else {
     W = 800;
     H = 480;
@@ -29,6 +32,7 @@ function resizeCanvas() {
 }
 resizeCanvas();
 window.addEventListener('resize', resizeCanvas);
+if (window.visualViewport) window.visualViewport.addEventListener('resize', resizeCanvas);
 
 // ==================== INPUT ====================
 const keys = {}, prev = {};
@@ -1922,9 +1926,9 @@ function drawMenu() {
   ctx.fillStyle = grad;
   ctx.fillRect(0, 0, W, H);
 
-  // Mountains
+  // Mountains — loop until we cover full canvas width (handles wide mobile screens)
   ctx.fillStyle = '#3A6A5A';
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i * 200 - 50 < W + 200; i++) {
     const bx = i * 200 - 50;
     const bh = 120 + i * 20;
     ctx.beginPath();


### PR DESCRIPTION
Fixes #28

## Changes

**Title screen mountains not filling width**
The mountain loop was hardcoded to 5 iterations × 200px = 1000px coverage. On mobile landscape, `W` can be 1000–1100px, leaving a bare strip on the right edge. Now loops until `i * 200 - 50 < W + 200`, covering any canvas width.

**Bottom of map going off-screen / player falls out of view**
Root cause: `cam.y` was clamped to `[0, level.ROWS * TS - H]`. Since `H` was always hardcoded to 480 and the level is 480px tall, the clamp collapsed to `[0, 0]` — no vertical scrolling ever happened. On devices where `100vh` exceeds the physical screen height (iOS Safari landscape), the canvas overflowed and the bottom tiles were unreachable.

Fix: `resizeCanvas` now sets `H = min(480, visualViewport.height)` on mobile landscape. With a typical phone height of ~390px, `H = 390` and `cam.y` can range `[0, 90px]`. The existing Y-tracking code in `updateCamera` activates automatically — no further changes needed.

Also added a `visualViewport` resize listener so the canvas re-sizes when browser chrome shows/hides.

## Test plan
- [ ] On desktop: title screen mountains still fill the full width, no visual change
- [ ] On mobile landscape: title screen mountains reach the right edge with no gap
- [ ] On mobile landscape: falling into a water trap keeps the player in the visible area as the camera scrolls down to follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)