### PR TITLE
Clarify hi score UI to distinguish device vs global leaderboard

### DIFF
--- a/game.js
+++ b/game.js
@@ -2011,7 +2011,8 @@ function drawMenu() {
   if (showLeaderboard) {
     ctx.fillStyle = '#FFD700';
     ctx.font = 'bold 14px Courier New';
-    ctx.fillText('TOP  TRAIL  BLAZERS', LOGI_W / 2, panelY + 18);
+    // Issue #30: Clarify that this is the global cloud leaderboard, not local
+    ctx.fillText('GLOBAL  TOP  TRAIL  BLAZERS', LOGI_W / 2, panelY + 18);
 
     ctx.font = '12px Courier New';
     const rowHeight = 16;
@@ -2044,10 +2045,11 @@ function drawMenu() {
   }
 
   // High score
+  // Issue #30: Clarify that this is device-local score stored in localStorage
   if (game.hiScore > 0) {
     ctx.fillStyle = '#FFD700';
     ctx.font = 'bold 14px Courier New';
-    ctx.fillText(`HI SCORE: ${game.hiScore}`, LOGI_W / 2, LOGI_H - 20);
+    ctx.fillText(`DEVICE HI SCORE: ${game.hiScore}`, LOGI_W / 2, LOGI_H - 20);
   }
 
   ctx.restore();


### PR DESCRIPTION
Fixes #30

## Changes
- Renamed 'HI SCORE' label to 'DEVICE HI SCORE' to clarify the locally-stored score in browser localStorage
- Renamed 'TOP TRAIL BLAZERS' to 'GLOBAL TOP TRAIL BLAZERS' to clarify this is the cloud-based leaderboard
- Added inline comments documenting the fix for issue #30

## Problem Statement
Players were confused about how the local hi score relates to the central leaderboard. The UI didn't make it clear that these were two separate systems:
- Local hi score: Stored in browser localStorage, specific to each device
- Global leaderboard: Cloud-synced to Firebase, visible to all players

## Solution
By adding descriptive prefixes ('DEVICE' and 'GLOBAL'), it's now immediately clear which scoring system is which. Players won't wonder if their local high score affects the global rankings.