### PR TITLE
Allow defeating enemies during invincibility frames

### DIFF
--- a/game.js
+++ b/game.js
@@ -723,8 +723,11 @@ function updatePlayer() {
   }
 
   // Enemy collisions
+  // Issue #16: Allow defeating enemies even during invincibility frames.
+  // Players can stomp, glissade, and spray during hurtTimer, but can't take additional damage.
+  // This maintains challenge and allows defeating water-spawned enemies.
   enemies.forEach(e => {
-    if (!e.alive || player.hurtTimer > 0) return;
+    if (!e.alive) return;
     if (!aabb(player, e)) return;
 
     // Glissade: kill already-stunned enemies, stun others
@@ -749,7 +752,8 @@ function updatePlayer() {
         e.stunTimer = 60;
         player.vy = -8;
       }
-    } else if (e.stunTimer === 0) {
+    } else if (e.stunTimer === 0 && player.hurtTimer === 0) {
+      // Only take damage if not currently invincible
       hurtPlayer();
     }
   });


### PR DESCRIPTION
Fixes #16

## Problem
Enemies spawned in water were unreachable because:
- Water damages the player on contact
- Player becomes invincible/blinking after taking damage
- Enemy collision was completely disabled during invincibility
- Result: Impossible to defeat water-spawned enemies

## Solution
Implement classic platformer invincibility mechanics:
- Players CAN stomp, glissade, and spray enemies during blinking
- Players CANNOT take additional damage during blinking
- Only damage is blocked, not combat interaction

## Changes
- Removed \player.hurtTimer > 0\ from enemy collision skip
- Contact damage now only triggers when \player.hurtTimer === 0\
- Added detailed comments explaining the fix

## Impact
- Water-spawned enemies are now defeatable
- Increases difficulty of Trail Angel achievement
- Aligns with standard platformer player expectations
- Makes invincibility frames work as players intuitively expect