### PR TITLE
Add time-based scoring system

### DIFF
--- a/game.js
+++ b/game.js
@@ -2128,9 +2128,16 @@ function drawLevelComplete() {
   const levelDistances = [3744, 4704, 5664]; // goal x positions in pixels
   const theoreticalFrames = levelDistances[game.levelNum] / 3.5;
   const targetTime = Math.ceil(theoreticalFrames / 60 * 1.8); // 1.8x buffer for obstacles, jumping, enemies
-  // Exponential bonus/penalty: 100 points at target, scales with 1.1^seconds_diff
+  // Hybrid bonus/penalty: exponential for speed bonuses, linear for time penalties
   const timeDiff = targetTime - timeSeconds;
-  const timeBonus = Math.floor(100 * Math.pow(1.1, timeDiff));
+  let timeBonus;
+  if (timeDiff >= 0) {
+    // Exponential bonus for fast times (big rewards for speed)
+    timeBonus = Math.floor(100 * Math.pow(1.1, timeDiff));
+  } else {
+    // Linear penalty for slow times (gentler penalties for slowness)
+    timeBonus = Math.floor(timeDiff * 5); // 5 points per second over target
+  }
   player.score += timeBonus; // Always apply, even if negative
   ctx.fillText(`Time: ${timeStr}`, W / 2, H / 2 + 65);
   ctx.fillStyle = timeBonus >= 0 ? '#FFFF88' : '#FF8888';


### PR DESCRIPTION
Fixes #19

## Problem
There was a hard cap on maximum score when players collected all items and defeated all enemies. No incentive to play faster.

## Solution
Implement per-level time-based scoring with hybrid exponential bonuses and linear penalties:
- **Timer display**: Show current level time on status bar (MM:SS format)
- **Physics-based targets**: Calculated from level distance (3744px, 4704px, 5664px) and player speed (3.5px/frame)
- **Hybrid scoring**: Exponential rewards for fast times, linear penalties for slow times
- **Level complete screen**: Display completion time and earned bonus/penalty
- **Score integration**: Bonus/penalty added immediately to player score

## Changes
- Added \levelCompletionTime\ property to game object
- Display timer on status bar during gameplay
- Calculate and award time bonus/penalty on level completion
- Show time and bonus/penalty on level complete screen
- Reset timer when starting new levels

## Scoring Details
**Formula:**
- Fast times (≥ target): \100 × 1.1^seconds_under\ (exponential bonus)
- Slow times (< target): \-5 × seconds_over\ (linear penalty)

**Examples:**
- 20s faster than target: ~673 points (massive reward!)
- On target time: 100 points (fair baseline)
- 20s slower than target: -100 points (moderate penalty)

## Impact
- Removes hard score cap by rewarding faster completion
- Encourages skillful, efficient play
- Maintains existing scoring for items and enemies
- Creates replayability through speed challenges