### PR TITLE
Fix HUD spacing for time display on level screen

### DIFF
--- a/game.js
+++ b/game.js
@@ -1808,11 +1808,11 @@ function drawHUD() {
 
   // Health (water drops)
   ctx.fillStyle = '#AAF';
-  ctx.fillText('H2O:', 160, 22);
+  ctx.fillText('H2O:', 140, 22);
   for (let i = 0; i < 3; i++) {
     ctx.fillStyle = i < player.health ? '#4169E1' : '#333';
     ctx.beginPath();
-    ctx.arc(210 + i * 20, 18, 7, 0, Math.PI * 2);
+    ctx.arc(190 + i * 20, 18, 7, 0, Math.PI * 2);
     ctx.fill();
   }
 
@@ -1833,7 +1833,7 @@ function drawHUD() {
   ctx.fillStyle = '#88DDFF';
   ctx.font = 'bold 12px Courier New';
   ctx.textAlign = 'left';
-  ctx.fillText(`TIME: ${timeStr}`, 300, 22);
+  ctx.fillText(`TIME: ${timeStr}`, 260, 22);
   ctx.textAlign = 'right';
 
   // Trail progress bar


### PR DESCRIPTION
Fixes the time HUD layout on level play for issue #19.

- Evenly space LIVES, H2O, TIME, and central score/level name elements in the HUD.
- Move H2O and timer text horizontally to reduce crowding and improve readability.
- Keeps HUD compact while avoiding overlapping or cramped layout.

This ships the final HUD polish for the time-based scoring update.
