### PR TITLE
Increase speed bonus target time multiplier to 4x

### DIFF
--- a/SCORING.md
+++ b/SCORING.md
@@ -20,22 +20,22 @@ min_time = (goalTile * 32px) / MOVE_SPEED / 60fps
 
 This is the absolute floor — a straight sprint with no vertical movement, no enemies, no platforming at all. No real playthrough can approach it.
 
-### Target Time Multiplier: 3×
+### Target Time Multiplier: 4×
 
-The target time used for scoring = **3× the theoretical minimum**:
+The target time used for scoring = **4× the theoretical minimum**:
 
 | Level | Target Time |
 |---|---|
-| Meadow Trail | ~53s |
-| Pine Ridge | ~67s |
-| Alpine Pass | ~81s |
+| Meadow Trail | ~71s |
+| Pine Ridge | ~90s |
+| Alpine Pass | ~108s |
 
-**Why 3×?**
+**Why 4×?**
 
 - 1× (theoretical min) is physically impossible in a real playthrough.
 - 2× (≈37s/47s/56s) — the original formula — was also nearly impossible. A skilled player who skips all enemies and gear still couldn't beat it consistently. This caused large negative bonuses on almost every run.
-- 4× (≈71s/90s/108s) was considered but felt too forgiving — little pressure to move quickly.
-- 3× is the sweet spot: a fast, focused run that skips most enemies and some gear can beat the target; a casual exploratory run ends up slightly under.
+- 3× (≈53s/67s/81s) was the previous setting — provided good challenge but still quite difficult for casual players.
+- 4× provides a more forgiving target: most players can achieve positive bonuses with reasonable effort, while still rewarding skilled, fast playthroughs.
 
 ### Speed Bonus Formula
 

--- a/game.js
+++ b/game.js
@@ -800,10 +800,10 @@ function updatePlayer() {
     game.trailAngel[game.levelNum] = enemies.every(en => !en.alive);
     game.levelCompletionTime = game.levelTick; // Store completion time for bonus calculation
     const timeSeconds = Math.floor(game.levelTick / 60);
-    // Target = 3× theoretical minimum sprint time (goalTile * 32px / 3.5px/tick / 60fps)
-    // L1: ~53s, L2: ~67s, L3: ~81s
+    // Target = 4× theoretical minimum sprint time (goalTile * 32px / 3.5px/tick / 60fps)
+    // L1: ~71s, L2: ~90s, L3: ~108s
     const levelDistances = [117 * 32, 147 * 32, 177 * 32];
-    const targetTime = Math.ceil(levelDistances[game.levelNum] / 3.5 / 60 * 3);
+    const targetTime = Math.ceil(levelDistances[game.levelNum] / 3.5 / 60 * 4);
     const timeDiff = targetTime - timeSeconds;
     game.levelTimeBonus = timeDiff >= 0
       ? Math.min(500, Math.floor(50 * Math.pow(1.04, timeDiff)))  // speed bonus, capped at 500


### PR DESCRIPTION
Increases the speed bonus target time multiplier from 3x to 4x for more forgiving time-based scoring.

**Changes:**
- Updated target time calculation in game.js from * 3 to * 4
- New target times: Meadow Trail (~71s), Pine Ridge (~90s), Alpine Pass (~108s)
- Updated SCORING.md documentation with new multiplier reasoning
- More players can now achieve positive bonuses while still rewarding fast playthroughs

**Rationale:**
The previous 3x multiplier was quite challenging - most casual players couldn't beat the target times consistently. 4x provides a better balance: still encourages speed while being achievable for more players.

Closes #43