### PR TITLE
Play start jingle at beginning of every level, fix mobile audio

### DIFF
--- a/game.js
+++ b/game.js
@@ -974,6 +974,7 @@ function advanceLevel() {
   player.score = savedScore;
   player.lives = savedLives;
   game.state = 'playing';
+  audio.sfxStartJingle();
 }
 
 // ==================== DRAWING ====================
@@ -2453,11 +2454,15 @@ const audio = (() => {
   let masterGain = null;
 
   function init() {
-    if (ctx) return;
+    if (ctx) {
+      if (ctx.state === 'suspended') ctx.resume();
+      return;
+    }
     ctx = new (window.AudioContext || window.webkitAudioContext)();
     masterGain = ctx.createGain();
     masterGain.gain.value = 0.5;
     masterGain.connect(ctx.destination);
+    if (ctx.state === 'suspended') ctx.resume();
   }
 
   // Resume and return a Promise that resolves when ctx is running
@@ -2525,7 +2530,7 @@ const audio = (() => {
   function sfxGlissade()  { sfx(() => { noise(0.4, 0.16, 500); oscSweep('sawtooth', 260, 130, 0.4, 0.06); }); }
   function sfxStun()      { sfx(() => { oscSweep('sine', 400, 200, 0.18, 0.12); oscSweep('sine', 380, 190, 0.22, 0.08); }); }
 
-  // ---- startup jingle: cheerful C-E-G run, plays once when gameplay begins ----
+  // ---- startup jingle: cheerful C-E-G run, plays at the start of every level ----
   function sfxStartJingle() {
     sfx(() => {
       const t0 = ctx.currentTime;


### PR DESCRIPTION
## Summary

- Play the start jingle (ditty) at the beginning of every level, not just the first
- Fix mobile audio bug where the AudioContext stayed suspended, preventing the initial jingle from playing unless the user interacted again (e.g., jumping)

Closes #45

## Changes

1. **`advanceLevel()`**: Added `audio.sfxStartJingle()` call so levels 2 and 3 get the cheerful C-E-G jingle on entry
2. **`audio.init()`**: Now calls `ctx.resume()` when the AudioContext is suspended, ensuring it gets unlocked during the user gesture (tap/keypress) that triggers init — fixes the mobile bug where the jingle would not play until a subsequent interaction
3. Updated the `sfxStartJingle` comment to reflect that it now plays at the start of every level

## Test plan

- [ ] Start a new game — jingle plays on level 1 (unchanged behavior)
- [ ] Complete level 1 — jingle plays when level 2 starts
- [ ] Complete level 2 — jingle plays when level 3 starts
- [ ] On mobile: tap to start game — jingle plays immediately without needing to jump first

https://claude.ai/code/session_01RE7s13gYdRsYEuwV3hpKc1