### PR TITLE
Fix score display rendering on level complete screen

### DIFF
--- a/game.js
+++ b/game.js
@@ -3075,8 +3075,12 @@ function drawLevelComplete() {
   const timeBonus = game.levelTimeBonus;
   const lineHeight = 26;
   let infoY = H / 2 - 30;
+  ctx.fillStyle = '#FFFFFF';
+  ctx.font = 'bold 20px Courier New';
   ctx.fillText(`Score: ${player.score}`, W / 2, infoY);
-  infoY += lineHeight;
+  infoY += lineHeight + 4;
+  ctx.fillStyle = '#AADDFF';
+  ctx.font = '14px Courier New';
   ctx.fillText('Gear: ' + items.filter(i => i.collected).length + ' / ' + items.length, W / 2, infoY);
   infoY += lineHeight;
   ctx.fillText(`Time: ${timeStr}`, W / 2, infoY);


### PR DESCRIPTION
## Summary
- Fixes the score text being cut off on the level complete screen by increasing the font from 12px to bold 20px white
- Bumps gear/time stat font from 12px to 14px for better readability
- Adds slight extra spacing (4px) between the score and stat lines

Closes #52

## Test plan
- [ ] Complete a level and verify the score is fully visible on the level complete screen
- [ ] Check that gear count, time, speed bonus, awards, and next level text are all properly positioned
- [ ] Verify layout with both Leave No Trace and Trail Angel awards showing simultaneously

https://claude.ai/code/session_01M6bL7YnWTUF4nDXJXR5nvC