### PR TITLE
Fix enemies spawning in water on level 3 (closes #59)

### DIFF
--- a/game.js
+++ b/game.js
@@ -262,11 +262,11 @@ const LEVELS = [
     spawnEnemies() {
       return [
         makeMarmot(12,8), makeMarmot(35, 8), makeMarmot(82, 8), makeMarmot(123, 10),
-        makeMouse(46, 8), makeMouse(76, 8), makeMouse(100, 7),
+        makeMouse(46, 8), makeMouse(79, 8), makeMouse(100, 7),
         makeMosquito(27, 7), makeMosquito(50, 4), makeMosquito(71, 7),
         makeMosquito(90, 4), makeMosquito(130, 4),
         makeHiker(60, 7), makeHiker(94, 6), makeHiker(138, 5),
-        makeRedneck(113, 9), makeRedneck(143, 5),
+        makeRedneck(120, 9), makeRedneck(143, 5),
       ];
     },
     spawnTPBlooms() {


### PR DESCRIPTION
## Summary

- **Mouse** at tile 76 moved to tile 79 — was inside Second Creek (tiles 68-77), now on the Fallen Logs section with solid ground at row 11
- **Redneck** at tile 113 moved to tile 120 — was inside Third Creek (tiles 108-117), now on the Final Ascent solid fill (tiles 119-122, rows 9-10)

Both enemies were falling through one-way platforms into the water below because they spawned inside/below platform tiles, bypassing the one-way collision check.

Closes #59

## Test plan

- [ ] Play level 3 and verify no enemies appear in the Second Creek (~46%) or Third Creek (~71%) water
- [ ] Confirm the mouse appears on solid ground near the Fallen Logs section (~53%)
- [ ] Confirm the redneck appears on solid ground at the Final Ascent (~80%)
- [ ] Verify enemy patrol behavior works correctly (ledge detection turns them at edges)

https://claude.ai/code/session_01RQpTrVtA8SuYpBioSmjJPj