### PR TITLE
Fix inaccessible redneck on Bridge of the Gods at 12%

### DIFF
--- a/game.js
+++ b/game.js
@@ -501,7 +501,7 @@ const LEVELS = [
         makeMosquito(168, 4),
         makeHiker(43, 8), makeHiker(77, 4), makeHiker(126, 5),
         makeHiker(162, 5), makeHiker(175, 7),
-        makeRedneck(21, 10), makeRedneck(62, 8),
+        makeRedneck(21, 8), makeRedneck(62, 8),
         makeRedneck(122, 7), makeRedneck(169, 7),
       ];
     },


### PR DESCRIPTION
## Summary

- The redneck at spawn tile (21, 10) on Bridge of the Gods was trapped in an enclosed pocket: solid walls at cols 19 and 24, a one-way platform above (row 9), and the solid floor below — completely unreachable by the player
- Fixed by moving the spawn to (21, 8) so the redneck falls onto the platform at row 9, where the player naturally traverses

## Test plan

- [ ] Play Bridge of the Gods and verify the redneck near 12% is on the platform and can be stomped, glissaded through, or sprayed
- [ ] Verify the redneck patrols correctly without escaping the platform area
- [ ] Confirm no regressions on other enemy placements in the level

🤖 Generated with [Claude Code](https://claude.com/claude-code)