### PR TITLE
Add debug tools and Playwright QA runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .claude/
 .worktrees/
+qa/node_modules/
+qa/screenshots/*.png

--- a/docs/superpowers/plans/2026-04-10-debug-tools.md
+++ b/docs/superpowers/plans/2026-04-10-debug-tools.md
@@ -1,0 +1,536 @@
+# Debug & Testing Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add in-game debug mode with level warp + dense overlay, a `window.trailBlazerDebug` API, and a `qa/` Playwright runner for headless automated testing.
+
+**Architecture:** All in-game debug code lives in a new `DEBUG` section inside `game.js`'s existing IIFE, inserted just before `MAIN LOOP`. The `window.trailBlazerDebug` object is exposed just before `BOOT`. Playwright tooling lives in a separate `qa/` directory with its own `package.json` — no build step is added to the root project.
+
+**Tech Stack:** Vanilla JS (game), Canvas 2D, Playwright (Node.js, `qa/` only, ESM)
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|---------|---------|
+| `game.js` | Modify | Add DEBUG section, FPS tracking, overlay, window API |
+| `.gitignore` | Modify | Ignore `qa/node_modules/` and `qa/screenshots/*.png` |
+| `qa/package.json` | Create | `"type": "module"`, playwright dep |
+| `qa/runner.mjs` | Create | CLI: launch headless browser, run a scenario file |
+| `qa/lib/game-client.mjs` | Create | Typed wrapper around `window.trailBlazerDebug` |
+| `qa/scenarios/smoke.mjs` | Create | Basic smoke test: warp, walk, screenshot, assert |
+| `qa/screenshots/.gitkeep` | Create | Keeps the output directory tracked in git |
+
+---
+
+## Task 1: Add DEBUG section to game.js
+
+**Files:**
+- Modify: `game.js` — insert before `// ==================== MAIN LOOP ====================`
+- Modify: `game.js` — update `update()` for FPS tracking
+- Modify: `game.js` — update `draw()` to call overlay
+
+- [ ] **Step 1: Insert the DEBUG section**
+
+In `game.js`, find this exact line:
+
+```
+// ==================== MAIN LOOP ====================
+```
+
+Insert the following block immediately before it (preserving the original line):
+
+```js
+// ==================== DEBUG ====================
+const dbg = {
+  url: new URLSearchParams(location.search).has('debug'),
+  human: false,
+};
+const isDebug = () => dbg.url || dbg.human;
+
+let fpsLastTime = 0;
+let fpsBuffer = []; // rolling 60-frame window of frame durations (ms)
+function getCurrentFps() {
+  if (fpsBuffer.length === 0) return 60;
+  const avg = fpsBuffer.reduce((a, b) => a + b, 0) / fpsBuffer.length;
+  return Math.round(1000 / avg);
+}
+
+function warpToLevel(n) {
+  initGame();                          // ensures player exists, state = 'playing'
+  loadLevel(n);                        // override initGame's level 0 with requested level
+  const spawn = LEVELS[n].spawnTile;
+  player.x = spawn[0] * TS;
+  player.y = spawn[1] * TS;
+  game.levelTick = 0;
+}
+
+addEventListener('keydown', e => {
+  if (e.ctrlKey && e.shiftKey && e.code === 'KeyD') {
+    dbg.human = !dbg.human;
+    e.preventDefault();
+    return;
+  }
+  if (isDebug() && e.ctrlKey && !e.shiftKey && !e.altKey) {
+    const n = parseInt(e.key) - 1; // Ctrl+1 → level index 0, Ctrl+9 → level index 8
+    if (!isNaN(n) && n >= 0 && n < LEVELS.length) {
+      audio.init();
+      warpToLevel(n);
+      e.preventDefault();
+    }
+  }
+});
+
+function drawDebugOverlay() {
+  if (!player) return;
+  const sx = x => Math.round(x - cam.x);
+  const sy = y => Math.round(y - cam.y);
+
+  ctx.save();
+  ctx.lineWidth = 1.5;
+
+  // Player hitbox — red
+  ctx.strokeStyle = '#ff3333';
+  ctx.strokeRect(sx(player.x), sy(player.y), player.w, player.h);
+
+  // Enemy hitboxes — orange
+  ctx.strokeStyle = '#ff9900';
+  enemies.forEach(e => {
+    if (e.alive) ctx.strokeRect(sx(e.x), sy(e.y), e.w, e.h);
+  });
+
+  // Item hitboxes — cyan (items use `collected` flag, not `alive`)
+  ctx.strokeStyle = '#00ffff';
+  items.forEach(it => {
+    if (!it.collected) ctx.strokeRect(sx(it.x), sy(it.y), it.w, it.h);
+  });
+
+  // TP Bloom hitboxes — magenta (blooms use `active` flag, not `alive`)
+  ctx.strokeStyle = '#ff00ff';
+  tpBlooms.forEach(b => {
+    if (b.active) ctx.strokeRect(sx(b.x), sy(b.y), b.w, b.h);
+  });
+
+  ctx.restore();
+
+  // Info readout — fixed top-left corner
+  const tx = Math.floor(player.x / TS);
+  const ty = Math.floor(player.y / TS);
+  const lines = [
+    `STATE:${game.state}  LEVEL:${game.levelNum + 1} (${LEVELS[game.levelNum].name})`,
+    `PLAYER tile:(${tx},${ty})  world:(${Math.floor(player.x)},${Math.floor(player.y)})`,
+    `vx:${player.vx.toFixed(2)}  vy:${player.vy.toFixed(2)}  onGround:${player.onGround}`,
+    `ENEMIES alive:${enemies.filter(e => e.alive).length}  ITEMS left:${items.filter(i => !i.collected).length}`,
+    `FPS:${getCurrentFps()}`,
+  ];
+  ctx.save();
+  ctx.font = '12px monospace';
+  const lh = 16, pad = 6, bw = 360, bh = lines.length * lh + pad * 2;
+  ctx.fillStyle = 'rgba(0,0,0,0.65)';
+  ctx.fillRect(4, 4, bw, bh);
+  ctx.fillStyle = '#ffffff';
+  lines.forEach((l, i) => ctx.fillText(l, 4 + pad, 4 + pad + 12 + i * lh));
+  ctx.restore();
+}
+
+```
+
+- [ ] **Step 2: Add FPS tracking at the top of update()**
+
+In `game.js`, find:
+
+```js
+function update() {
+  game.tick++;
+```
+
+Replace with:
+
+```js
+function update() {
+  if (isDebug()) {
+    const now = performance.now();
+    if (fpsLastTime > 0) {
+      fpsBuffer.push(now - fpsLastTime);
+      if (fpsBuffer.length > 60) fpsBuffer.shift();
+    }
+    fpsLastTime = now;
+  }
+  game.tick++;
+```
+
+- [ ] **Step 3: Call drawDebugOverlay at end of draw()**
+
+In `game.js`, find these exact lines (the closing of the `playing` state draw block):
+
+```js
+  drawBeerCans();
+  drawPlayer();
+  drawParticles();
+  drawFloatTexts();
+  drawHUD();
+}
+```
+
+Replace with:
+
+```js
+  drawBeerCans();
+  drawPlayer();
+  drawParticles();
+  drawFloatTexts();
+  drawHUD();
+  if (isDebug()) drawDebugOverlay();
+}
+```
+
+- [ ] **Step 4: Verify in browser**
+
+Start the server (`python -m http.server 3000`) and open `http://localhost:3000`.
+
+Test human toggle: press `Ctrl+Shift+D` — a dark overlay should appear at top-left showing STATE/LEVEL/PLAYER/FPS, and a red rectangle should outline the player. Press `Ctrl+Shift+D` again to hide.
+
+Test level warp: while overlay is visible, press `Ctrl+3` — game should jump to level 3 (index 2). The level name in the overlay should update. Press `Ctrl+1` to return to level 1.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add game.js
+git commit -m "feat: add DEBUG section with overlay, FPS counter, and level warp (closes #61, partial)"
+```
+
+---
+
+## Task 2: Add window.trailBlazerDebug API
+
+**Files:**
+- Modify: `game.js` — insert before `// ==================== BOOT ====================`
+
+- [ ] **Step 1: Insert the DEBUG API section**
+
+In `game.js`, find these exact lines:
+
+```js
+// ==================== BOOT ====================
+setupTouch();
+```
+
+Insert immediately before them:
+
+```js
+// ==================== DEBUG API ====================
+window.trailBlazerDebug = {
+  warpToLevel(n) {
+    warpToLevel(n);
+  },
+  screenshot() {
+    return canvas.toDataURL('image/png');
+  },
+  pressKey(code) {
+    keys[code] = true;
+  },
+  releaseKey(code) {
+    keys[code] = false;
+  },
+  getState() {
+    return {
+      state: game.state,
+      levelNum: game.levelNum,
+      levelTick: game.levelTick,
+      playerX: player ? player.x : null,
+      playerY: player ? player.y : null,
+      playerLives: player ? player.lives : null,
+      playerScore: player ? player.score : null,
+      enemyCount: enemies.filter(e => e.alive).length,
+      itemCount: items.filter(i => !i.collected).length,
+    };
+  },
+};
+
+```
+
+- [ ] **Step 2: Verify in DevTools**
+
+Open `http://localhost:3000?debug=1`, open the browser DevTools console, and run:
+
+```js
+window.trailBlazerDebug.warpToLevel(2)
+// game should jump to level 3
+
+window.trailBlazerDebug.getState()
+// should return an object: { state: 'playing', levelNum: 2, playerLives: 3, ... }
+
+typeof window.trailBlazerDebug.screenshot()
+// should return 'string' (a base64 data URL)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add game.js
+git commit -m "feat: expose window.trailBlazerDebug API for Playwright automation"
+```
+
+---
+
+## Task 3: Set up qa/ directory scaffold
+
+**Files:**
+- Create: `qa/package.json`
+- Create: `qa/screenshots/.gitkeep`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Create qa/package.json**
+
+```json
+{
+  "name": "trail-blazer-qa",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "install-browsers": "npx playwright install chromium"
+  },
+  "dependencies": {
+    "playwright": "^1.44.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create qa/screenshots/.gitkeep**
+
+Create an empty file at `qa/screenshots/.gitkeep` so the output directory exists in the repo without committing any PNG files.
+
+- [ ] **Step 3: Update .gitignore**
+
+The current `.gitignore` contains only `.claude/`. Add two more lines:
+
+```
+qa/node_modules/
+qa/screenshots/*.png
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add qa/package.json qa/screenshots/.gitkeep .gitignore
+git commit -m "chore: scaffold qa/ directory for Playwright automation"
+```
+
+---
+
+## Task 4: Create qa/lib/game-client.mjs
+
+**Files:**
+- Create: `qa/lib/game-client.mjs`
+
+- [ ] **Step 1: Create the file**
+
+```js
+import { writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const screenshotsDir = resolve(__dirname, '..', 'screenshots');
+
+export class GameClient {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async warpToLevel(n) {
+    await this.page.evaluate(n => window.trailBlazerDebug.warpToLevel(n), n);
+  }
+
+  // Saves the canvas as a PNG to qa/screenshots/<name>.png.
+  // Returns the absolute path so the caller can read it.
+  async screenshot(name) {
+    const dataUrl = await this.page.evaluate(() => window.trailBlazerDebug.screenshot());
+    const base64 = dataUrl.replace(/^data:image\/png;base64,/, '');
+    const filePath = resolve(screenshotsDir, `${name}.png`);
+    writeFileSync(filePath, Buffer.from(base64, 'base64'));
+    return filePath;
+  }
+
+  async pressKey(code) {
+    await this.page.evaluate(code => window.trailBlazerDebug.pressKey(code), code);
+  }
+
+  async releaseKey(code) {
+    await this.page.evaluate(code => window.trailBlazerDebug.releaseKey(code), code);
+  }
+
+  // Hold a key for `frames` game frames (~16ms each), then release.
+  async holdKey(code, frames) {
+    await this.pressKey(code);
+    await this.waitFrames(frames);
+    await this.releaseKey(code);
+  }
+
+  // Wait approximately n game frames (n * 16ms).
+  async waitFrames(n) {
+    await new Promise(r => setTimeout(r, n * 16));
+  }
+
+  async getState() {
+    return this.page.evaluate(() => window.trailBlazerDebug.getState());
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add qa/lib/game-client.mjs
+git commit -m "feat: add GameClient typed wrapper for Playwright scenarios"
+```
+
+---
+
+## Task 5: Create qa/runner.mjs
+
+**Files:**
+- Create: `qa/runner.mjs`
+
+- [ ] **Step 1: Create the file**
+
+```js
+import { chromium } from 'playwright';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { GameClient } from './lib/game-client.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const scenarioArg = process.argv[2];
+if (!scenarioArg) {
+  console.error('Usage: node runner.mjs scenarios/<name>.mjs');
+  process.exit(1);
+}
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage();
+
+try {
+  await page.goto('http://localhost:3000?debug=1');
+  await page.waitForFunction(
+    () => typeof window.trailBlazerDebug !== 'undefined',
+    { timeout: 10000 }
+  );
+
+  const scenarioPath = resolve(__dirname, scenarioArg);
+  const { default: scenario } = await import(scenarioPath);
+  const client = new GameClient(page);
+
+  await scenario(client);
+  console.log('Scenario completed successfully.');
+} catch (err) {
+  console.error('Scenario failed:', err.message);
+  process.exit(1);
+} finally {
+  await browser.close();
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add qa/runner.mjs
+git commit -m "feat: add Playwright runner for QA scenarios"
+```
+
+---
+
+## Task 6: Create smoke scenario and verify end-to-end
+
+**Files:**
+- Create: `qa/scenarios/smoke.mjs`
+
+- [ ] **Step 1: Create the scenario**
+
+```js
+// Smoke test: warp to levels 1 and 3, verify player state, screenshot initial frames.
+export default async function scenario(game) {
+  // --- Level 1 ---
+  await game.warpToLevel(0);
+  await game.waitFrames(10);
+
+  const s1 = await game.getState();
+  console.assert(s1.state === 'playing', `L1: expected playing, got ${s1.state}`);
+  console.assert(s1.levelNum === 0, `L1: expected levelNum 0, got ${s1.levelNum}`);
+  console.assert(s1.playerLives === 3, `L1: expected 3 lives, got ${s1.playerLives}`);
+  await game.screenshot('smoke-level-1-initial');
+  console.log('Level 1 initial state OK');
+
+  // Walk right for 2 seconds; player should survive
+  await game.holdKey('ArrowRight', 120);
+  await game.waitFrames(10);
+  const s1w = await game.getState();
+  console.assert(s1w.playerLives > 0, `L1: player died walking right`);
+  await game.screenshot('smoke-level-1-after-walk');
+  console.log('Level 1 walk OK');
+
+  // --- Level 3 ---
+  await game.warpToLevel(2);
+  await game.waitFrames(10);
+
+  const s3 = await game.getState();
+  console.assert(s3.state === 'playing', `L3: expected playing, got ${s3.state}`);
+  console.assert(s3.levelNum === 2, `L3: expected levelNum 2, got ${s3.levelNum}`);
+  await game.screenshot('smoke-level-3-initial');
+  console.log('Level 3 initial state OK');
+
+  console.log('Smoke test passed.');
+}
+```
+
+- [ ] **Step 2: Install Playwright and run the smoke test**
+
+Make sure a local server is running in the game root (open a separate terminal: `python -m http.server 3000`). Then:
+
+```bash
+cd qa
+npm install
+node runner.mjs scenarios/smoke.mjs
+```
+
+Expected output:
+```
+Level 1 initial state OK
+Level 1 walk OK
+Level 3 initial state OK
+Smoke test passed.
+Scenario completed successfully.
+```
+
+- [ ] **Step 3: Verify screenshots were written**
+
+Check that `qa/screenshots/` contains three PNG files. Read one of them to confirm the canvas rendered a real game frame (not a blank canvas).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add qa/scenarios/smoke.mjs
+git commit -m "feat: add smoke QA scenario covering level warp and basic navigation"
+```
+
+---
+
+## Final: Open PR
+
+```bash
+git push -u origin issue-61-debug-tools
+gh pr create \
+  --title "Add debug tools and Playwright QA runner" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds `Ctrl+Shift+D` in-game debug toggle: hitbox outlines, physics readout, FPS counter
+- Adds `Ctrl+1–9` level warp shortcut (active in debug mode)
+- Exposes `window.trailBlazerDebug` API (`warpToLevel`, `screenshot`, `pressKey`, `releaseKey`, `getState`) for automated testing
+- Adds `qa/` directory with Playwright runner and smoke scenario
+
+closes #61
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-10-debug-tools-design.md
+++ b/docs/superpowers/specs/2026-04-10-debug-tools-design.md
@@ -1,0 +1,182 @@
+# Debug & Testing Tools — Design Spec
+
+**Issue:** #61
+**Date:** 2026-04-10
+**Status:** Approved
+
+## Overview
+
+Add debugging and automated QA tools to Trail Blazer. Two audiences:
+
+1. **Playwright automation** (`?debug=1` URL param) — headless browser scripts that drive the game, take screenshots, and assert on state. Used by Claude during QA and bug validation.
+2. **Human QA** (`Ctrl+Shift+D` toggle) — dense in-game overlay showing hitboxes, physics values, and entity counts. Used when manually testing level design or bug reproduction.
+
+No build step is introduced. All in-game code stays inside the existing IIFE in `game.js`.
+
+---
+
+## 1. In-Game Debug Section (`game.js`)
+
+### Debug Flag
+
+A new `DEBUG` section added near the end of `game.js`, before the MAIN LOOP section:
+
+```js
+const dbg = {
+  url: new URLSearchParams(location.search).has('debug'),
+  human: false,  // toggled by Ctrl+Shift+D
+};
+const isDebug = () => dbg.url || dbg.human;
+```
+
+### Human Toggle
+
+In the existing `keydown` listener: when `e.ctrlKey && e.shiftKey && e.code === 'KeyD'`, flip `dbg.human`.
+
+### Level Warp
+
+Also in the `keydown` listener, gated on `isDebug()`:
+- `Ctrl+1` through `Ctrl+9` warp to level index 0–8 respectively.
+- Warp logic: call `initGame()` to ensure a clean player exists, then immediately call `loadLevel(n)` to override the level, reposition player at `LEVELS[n].spawnTile`, and reset `game.levelTick = 0`. Score resets to 0 (simplest behavior for a testing tool — no edge cases around warping from menu state).
+- Works from any game state (menu, playing, gameover, etc.).
+
+### FPS Counter
+
+A `fpsBuffer` array (rolling 60-frame window) tracks `performance.now()` deltas. Updated each frame at the top of `update()`. Current FPS = `1000 / avgDelta`.
+
+---
+
+## 2. Debug Overlay (`drawDebugOverlay()`)
+
+Called at the very end of `draw()` when `isDebug()` is true.
+
+### Hitboxes
+
+Drawn over all entities using their `x/y/w/h` fields, offset by `cam.x`/`cam.y` to convert world → screen coords:
+
+| Entity | Outline color |
+|--------|--------------|
+| Player | Red |
+| Enemies (alive) | Orange |
+| Items (alive) | Cyan |
+| TP Blooms (alive) | Magenta |
+
+Outlines are 1–2px strokes with no fill. Only drawn for entities on-screen (within viewport bounds).
+
+### Physics / State Readout
+
+Fixed position, top-left corner of the canvas. Semi-transparent dark background for legibility. Contents:
+
+```
+STATE: playing   LEVEL: 3 (Bridge of the Gods)
+PLAYER tile: (12, 9)   world: (384, 288)
+vx: 3.50   vy: -2.10   onGround: false
+ENEMIES alive: 4   ITEMS left: 2
+FPS: 60
+```
+
+Player tile coords = `Math.floor(player.x / TS)`, `Math.floor(player.y / TS)`.
+
+---
+
+## 3. `window.trailBlazerDebug` API
+
+Exposed unconditionally at the bottom of the IIFE (before the closing `})()`), so Playwright can always reach it when loading with `?debug=1`:
+
+```js
+window.trailBlazerDebug = {
+  // Warp to level index n (0–8). Resets levelTick and score to 0.
+  warpToLevel(n),
+
+  // Returns canvas.toDataURL('image/png') — a base64 PNG of the current frame.
+  screenshot(),
+
+  // Simulate a keypress (sets keys[code] = true).
+  pressKey(code),
+
+  // Release a simulated keypress (sets keys[code] = false).
+  releaseKey(code),
+
+  // Returns a plain-object snapshot of current game state:
+  // { state, levelNum, levelTick, playerX, playerY,
+  //   playerLives, playerScore, enemyCount, itemCount }
+  getState(),
+};
+```
+
+`pressKey`/`releaseKey` write directly into the `keys` object the game already reads — no special-casing in the game loop.
+
+---
+
+## 4. `qa/` Directory
+
+```
+qa/
+  package.json          — { "type": "module" }, dep: playwright
+  runner.mjs            — CLI entry point
+  lib/
+    game-client.mjs     — typed wrapper around window.trailBlazerDebug
+  scenarios/            — one .mjs file per QA scenario
+  screenshots/          — ephemeral output PNGs (.gitignored)
+```
+
+`qa/package.json` is scoped to the `qa/` subdirectory. It has no effect on the root project, which intentionally has no `package.json`.
+
+### `runner.mjs`
+
+Usage:
+```bash
+cd qa && npm install   # once
+node runner.mjs scenarios/level-3-smoke.mjs
+```
+
+Behavior:
+1. Launch headless Chromium via Playwright.
+2. Navigate to `http://localhost:3000?debug=1`.
+3. Wait for `window.trailBlazerDebug` to be defined.
+4. Dynamically import the scenario file; call `scenario(client)`.
+5. Close the browser and exit.
+
+### `game-client.mjs`
+
+Wraps every `window.trailBlazerDebug` call so scenario code reads cleanly:
+
+```js
+class GameClient {
+  async warpToLevel(n)         // calls window.trailBlazerDebug.warpToLevel(n)
+  async screenshot(name)       // saves PNG to qa/screenshots/<name>.png; returns path
+  async pressKey(code)         // calls pressKey(code)
+  async releaseKey(code)       // calls releaseKey(code)
+  async holdKey(code, frames)  // press, wait frames*16ms, release
+  async waitFrames(n)          // waits n * 16ms
+  async getState()             // returns getState() snapshot
+}
+```
+
+`screenshot(name)` saves the PNG to `qa/screenshots/<name>.png` for Claude to read with the `Read` tool. Screenshots are ephemeral QA artifacts — not committed to the repo.
+
+### Scenarios
+
+Each scenario is a plain async function:
+
+```js
+// scenarios/level-3-smoke.mjs
+export default async function scenario(game) {
+  await game.warpToLevel(2);
+  await game.waitFrames(60);
+  await game.screenshot('level-3-initial');
+  await game.holdKey('ArrowRight', 120);
+  await game.screenshot('level-3-after-walk');
+  const s = await game.getState();
+  console.assert(s.playerLives > 0, 'player should be alive after walking right');
+}
+```
+
+---
+
+## Out of Scope
+
+- Tile grid overlay (explicitly excluded per design discussion)
+- Any changes to the touch control layer
+- Leaderboard bypass or score manipulation
+- Automated CI integration (scenarios run manually by Claude on demand)

--- a/game.js
+++ b/game.js
@@ -3387,14 +3387,19 @@ function getCurrentFps() {
 }
 
 function warpToLevel(n) {
-  game.leaveNoTrace = [];
-  game.trailAngel = [];
-  game.tick = 0;
+  if (n < 0 || n >= LEVELS.length) {
+    console.warn(`warpToLevel: invalid level index ${n} (valid: 0–${LEVELS.length - 1})`);
+    return;
+  }
+  const savedScore = player ? player.score : 0;
+  const savedLives = player ? player.lives : 3;
   loadLevel(n);
   player = makePlayer();
   const spawn = LEVELS[n].spawnTile;
   player.x = spawn[0] * TS;
   player.y = spawn[1] * TS;
+  player.score = savedScore;
+  player.lives = savedLives;
   game.levelTick = 0;
   game.state = 'playing';
 }
@@ -3402,15 +3407,24 @@ function warpToLevel(n) {
 addEventListener('keydown', e => {
   if (e.ctrlKey && e.shiftKey && e.code === 'KeyD') {
     dbg.human = !dbg.human;
+    if (dbg.human) { fpsLastTime = 0; fpsBuffer = []; } // reset stale FPS state on enable
     e.preventDefault();
     return;
   }
+  // Note: Ctrl+1–9 conflicts with browser tab-switching shortcuts.
+  // preventDefault only suppresses the page event; the browser may
+  // still switch tabs. Use the window.trailBlazerDebug.warpToLevel()
+  // API (e.g. from DevTools console) as a reliable alternative.
   if (isDebug() && e.ctrlKey && !e.shiftKey && !e.altKey) {
-    const n = parseInt(e.key) - 1; // Ctrl+1 → level index 0, Ctrl+9 → level index 8
-    if (!isNaN(n) && n >= 0 && n < LEVELS.length) {
-      audio.init();
-      warpToLevel(n);
-      e.preventDefault();
+    // Use e.code (layout-independent) to detect digit keys — e.key varies by keyboard layout
+    const m = e.code.match(/^Digit([1-9])$/);
+    if (m) {
+      const n = parseInt(m[1]) - 1; // Ctrl+1 → level index 0, Ctrl+9 → level index 8
+      if (n < LEVELS.length) {
+        audio.init();
+        warpToLevel(n);
+        e.preventDefault();
+      }
     }
   }
 });

--- a/game.js
+++ b/game.js
@@ -3387,12 +3387,16 @@ function getCurrentFps() {
 }
 
 function warpToLevel(n) {
-  initGame();                          // ensures player exists, state = 'playing'
-  loadLevel(n);                        // override initGame's level 0 with requested level
+  game.leaveNoTrace = [];
+  game.trailAngel = [];
+  game.tick = 0;
+  loadLevel(n);
+  player = makePlayer();
   const spawn = LEVELS[n].spawnTile;
   player.x = spawn[0] * TS;
   player.y = spawn[1] * TS;
   game.levelTick = 0;
+  game.state = 'playing';
 }
 
 addEventListener('keydown', e => {

--- a/game.js
+++ b/game.js
@@ -3371,8 +3371,108 @@ function drawWin() {
   }
 }
 
+// ==================== DEBUG ====================
+const dbg = {
+  url: new URLSearchParams(location.search).has('debug'),
+  human: false,
+};
+const isDebug = () => dbg.url || dbg.human;
+
+let fpsLastTime = 0;
+let fpsBuffer = []; // rolling 60-frame window of frame durations (ms)
+function getCurrentFps() {
+  if (fpsBuffer.length === 0) return 60;
+  const avg = fpsBuffer.reduce((a, b) => a + b, 0) / fpsBuffer.length;
+  return Math.round(1000 / avg);
+}
+
+function warpToLevel(n) {
+  initGame();                          // ensures player exists, state = 'playing'
+  loadLevel(n);                        // override initGame's level 0 with requested level
+  const spawn = LEVELS[n].spawnTile;
+  player.x = spawn[0] * TS;
+  player.y = spawn[1] * TS;
+  game.levelTick = 0;
+}
+
+addEventListener('keydown', e => {
+  if (e.ctrlKey && e.shiftKey && e.code === 'KeyD') {
+    dbg.human = !dbg.human;
+    e.preventDefault();
+    return;
+  }
+  if (isDebug() && e.ctrlKey && !e.shiftKey && !e.altKey) {
+    const n = parseInt(e.key) - 1; // Ctrl+1 → level index 0, Ctrl+9 → level index 8
+    if (!isNaN(n) && n >= 0 && n < LEVELS.length) {
+      audio.init();
+      warpToLevel(n);
+      e.preventDefault();
+    }
+  }
+});
+
+function drawDebugOverlay() {
+  if (!player) return;
+  const sx = x => Math.round(x - cam.x);
+  const sy = y => Math.round(y - cam.y);
+
+  ctx.save();
+  ctx.lineWidth = 1.5;
+
+  // Player hitbox — red
+  ctx.strokeStyle = '#ff3333';
+  ctx.strokeRect(sx(player.x), sy(player.y), player.w, player.h);
+
+  // Enemy hitboxes — orange
+  ctx.strokeStyle = '#ff9900';
+  enemies.forEach(e => {
+    if (e.alive) ctx.strokeRect(sx(e.x), sy(e.y), e.w, e.h);
+  });
+
+  // Item hitboxes — cyan (items use `collected` flag, not `alive`)
+  ctx.strokeStyle = '#00ffff';
+  items.forEach(it => {
+    if (!it.collected) ctx.strokeRect(sx(it.x), sy(it.y), it.w, it.h);
+  });
+
+  // TP Bloom hitboxes — magenta (blooms use `active` flag, not `alive`)
+  ctx.strokeStyle = '#ff00ff';
+  tpBlooms.forEach(b => {
+    if (b.active) ctx.strokeRect(sx(b.x), sy(b.y), b.w, b.h);
+  });
+
+  ctx.restore();
+
+  // Info readout — fixed top-left corner
+  const tx = Math.floor(player.x / TS);
+  const ty = Math.floor(player.y / TS);
+  const lines = [
+    `STATE:${game.state}  LEVEL:${game.levelNum + 1} (${LEVELS[game.levelNum].name})`,
+    `PLAYER tile:(${tx},${ty})  world:(${Math.floor(player.x)},${Math.floor(player.y)})`,
+    `vx:${player.vx.toFixed(2)}  vy:${player.vy.toFixed(2)}  onGround:${player.onGround}`,
+    `ENEMIES alive:${enemies.filter(e => e.alive).length}  ITEMS left:${items.filter(i => !i.collected).length}`,
+    `FPS:${getCurrentFps()}`,
+  ];
+  ctx.save();
+  ctx.font = '12px monospace';
+  const lh = 16, pad = 6, bw = 360, bh = lines.length * lh + pad * 2;
+  ctx.fillStyle = 'rgba(0,0,0,0.65)';
+  ctx.fillRect(4, 4, bw, bh);
+  ctx.fillStyle = '#ffffff';
+  lines.forEach((l, i) => ctx.fillText(l, 4 + pad, 4 + pad + 12 + i * lh));
+  ctx.restore();
+}
+
 // ==================== MAIN LOOP ====================
 function update() {
+  if (isDebug()) {
+    const now = performance.now();
+    if (fpsLastTime > 0) {
+      fpsBuffer.push(now - fpsLastTime);
+      if (fpsBuffer.length > 60) fpsBuffer.shift();
+    }
+    fpsLastTime = now;
+  }
   game.tick++;
 
   if (game.state === 'menu') {
@@ -3509,6 +3609,7 @@ function draw() {
   drawParticles();
   drawFloatTexts();
   drawHUD();
+  if (isDebug()) drawDebugOverlay();
 }
 
 // ==================== AUDIO ====================

--- a/game.js
+++ b/game.js
@@ -3882,6 +3882,35 @@ addEventListener('keydown', e => {
   }
 });
 
+// ==================== DEBUG API ====================
+window.trailBlazerDebug = {
+  warpToLevel(n) {
+    warpToLevel(n);
+  },
+  screenshot() {
+    return canvas.toDataURL('image/png');
+  },
+  pressKey(code) {
+    keys[code] = true;
+  },
+  releaseKey(code) {
+    keys[code] = false;
+  },
+  getState() {
+    return {
+      state: game.state,
+      levelNum: game.levelNum,
+      levelTick: game.levelTick,
+      playerX: player ? player.x : null,
+      playerY: player ? player.y : null,
+      playerLives: player ? player.lives : null,
+      playerScore: player ? player.score : null,
+      enemyCount: enemies.filter(e => e.alive).length,
+      itemCount: items.filter(i => !i.collected).length,
+    };
+  },
+};
+
 // ==================== BOOT ====================
 setupTouch();
 fetchLeaderboard();

--- a/qa/lib/game-client.mjs
+++ b/qa/lib/game-client.mjs
@@ -1,0 +1,50 @@
+import { writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const screenshotsDir = resolve(__dirname, '..', 'screenshots');
+
+export class GameClient {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async warpToLevel(n) {
+    await this.page.evaluate(n => window.trailBlazerDebug.warpToLevel(n), n);
+  }
+
+  // Saves the canvas as a PNG to qa/screenshots/<name>.png.
+  // Returns the absolute path so the caller can read it.
+  async screenshot(name) {
+    const dataUrl = await this.page.evaluate(() => window.trailBlazerDebug.screenshot());
+    const base64 = dataUrl.replace(/^data:image\/png;base64,/, '');
+    const filePath = resolve(screenshotsDir, `${name}.png`);
+    writeFileSync(filePath, Buffer.from(base64, 'base64'));
+    return filePath;
+  }
+
+  async pressKey(code) {
+    await this.page.evaluate(code => window.trailBlazerDebug.pressKey(code), code);
+  }
+
+  async releaseKey(code) {
+    await this.page.evaluate(code => window.trailBlazerDebug.releaseKey(code), code);
+  }
+
+  // Hold a key for `frames` game frames (~16ms each), then release.
+  async holdKey(code, frames) {
+    await this.pressKey(code);
+    await this.waitFrames(frames);
+    await this.releaseKey(code);
+  }
+
+  // Wait approximately n game frames (n * 16ms).
+  async waitFrames(n) {
+    await new Promise(r => setTimeout(r, n * 16));
+  }
+
+  async getState() {
+    return this.page.evaluate(() => window.trailBlazerDebug.getState());
+  }
+}

--- a/qa/package-lock.json
+++ b/qa/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "trail-blazer-qa",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "trail-blazer-qa",
+      "dependencies": {
+        "playwright": "^1.44.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/qa/package.json
+++ b/qa/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "trail-blazer-qa",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "install-browsers": "npx playwright install chromium"
+  },
+  "dependencies": {
+    "playwright": "^1.44.0"
+  }
+}

--- a/qa/runner.mjs
+++ b/qa/runner.mjs
@@ -1,0 +1,35 @@
+import { chromium } from 'playwright';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { GameClient } from './lib/game-client.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const scenarioArg = process.argv[2];
+if (!scenarioArg) {
+  console.error('Usage: node runner.mjs scenarios/<name>.mjs');
+  process.exit(1);
+}
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage();
+
+try {
+  await page.goto('http://localhost:3000?debug=1');
+  await page.waitForFunction(
+    () => typeof window.trailBlazerDebug !== 'undefined',
+    { timeout: 10000 }
+  );
+
+  const scenarioPath = resolve(__dirname, scenarioArg);
+  const { default: scenario } = await import(scenarioPath);
+  const client = new GameClient(page);
+
+  await scenario(client);
+  console.log('Scenario completed successfully.');
+} catch (err) {
+  console.error('Scenario failed:', err.message);
+  process.exit(1);
+} finally {
+  await browser.close();
+}

--- a/qa/runner.mjs
+++ b/qa/runner.mjs
@@ -11,10 +11,12 @@ if (!scenarioArg) {
   process.exit(1);
 }
 
-const browser = await chromium.launch({ headless: true });
-const page = await browser.newPage();
-
+let browser;
+let exitCode = 0;
 try {
+  browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
   await page.goto('http://localhost:3000?debug=1');
   await page.waitForFunction(
     () => typeof window.trailBlazerDebug !== 'undefined',
@@ -28,8 +30,9 @@ try {
   await scenario(client);
   console.log('Scenario completed successfully.');
 } catch (err) {
-  console.error('Scenario failed:', err.message);
-  process.exit(1);
+  console.error('Scenario failed:', err.stack ?? err.message);
+  exitCode = 1;
 } finally {
-  await browser.close();
+  if (browser) await browser.close();
 }
+process.exit(exitCode);

--- a/qa/runner.mjs
+++ b/qa/runner.mjs
@@ -1,6 +1,6 @@
 import { chromium } from 'playwright';
 import { resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { GameClient } from './lib/game-client.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -24,7 +24,7 @@ try {
   );
 
   const scenarioPath = resolve(__dirname, scenarioArg);
-  const { default: scenario } = await import(scenarioPath);
+  const { default: scenario } = await import(pathToFileURL(scenarioPath).href);
   const client = new GameClient(page);
 
   await scenario(client);

--- a/qa/scenarios/smoke.mjs
+++ b/qa/scenarios/smoke.mjs
@@ -1,0 +1,33 @@
+// Smoke test: warp to levels 1 and 3, verify player state, screenshot initial frames.
+export default async function scenario(game) {
+  // --- Level 1 ---
+  await game.warpToLevel(0);
+  await game.waitFrames(10);
+
+  const s1 = await game.getState();
+  console.assert(s1.state === 'playing', `L1: expected playing, got ${s1.state}`);
+  console.assert(s1.levelNum === 0, `L1: expected levelNum 0, got ${s1.levelNum}`);
+  console.assert(s1.playerLives === 3, `L1: expected 3 lives, got ${s1.playerLives}`);
+  await game.screenshot('smoke-level-1-initial');
+  console.log('Level 1 initial state OK');
+
+  // Walk right for 2 seconds; player should survive
+  await game.holdKey('ArrowRight', 120);
+  await game.waitFrames(10);
+  const s1w = await game.getState();
+  console.assert(s1w.playerLives > 0, `L1: player died walking right`);
+  await game.screenshot('smoke-level-1-after-walk');
+  console.log('Level 1 walk OK');
+
+  // --- Level 3 ---
+  await game.warpToLevel(2);
+  await game.waitFrames(10);
+
+  const s3 = await game.getState();
+  console.assert(s3.state === 'playing', `L3: expected playing, got ${s3.state}`);
+  console.assert(s3.levelNum === 2, `L3: expected levelNum 2, got ${s3.levelNum}`);
+  await game.screenshot('smoke-level-3-initial');
+  console.log('Level 3 initial state OK');
+
+  console.log('Smoke test passed.');
+}

--- a/qa/scenarios/smoke.mjs
+++ b/qa/scenarios/smoke.mjs
@@ -1,21 +1,26 @@
 // Smoke test: warp to levels 1 and 3, verify player state, screenshot initial frames.
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(`Assertion failed: ${msg}`);
+}
+
 export default async function scenario(game) {
   // --- Level 1 ---
   await game.warpToLevel(0);
   await game.waitFrames(10);
 
   const s1 = await game.getState();
-  console.assert(s1.state === 'playing', `L1: expected playing, got ${s1.state}`);
-  console.assert(s1.levelNum === 0, `L1: expected levelNum 0, got ${s1.levelNum}`);
-  console.assert(s1.playerLives === 3, `L1: expected 3 lives, got ${s1.playerLives}`);
+  assert(s1.state === 'playing', `L1: expected playing, got ${s1.state}`);
+  assert(s1.levelNum === 0, `L1: expected levelNum 0, got ${s1.levelNum}`);
+  assert(s1.playerLives === 3, `L1: expected 3 lives, got ${s1.playerLives}`);
   await game.screenshot('smoke-level-1-initial');
   console.log('Level 1 initial state OK');
 
-  // Walk right for 2 seconds; player should survive
+  // Walk right for 2 seconds; player should survive with no lives lost
   await game.holdKey('ArrowRight', 120);
   await game.waitFrames(10);
   const s1w = await game.getState();
-  console.assert(s1w.playerLives > 0, `L1: player died walking right`);
+  assert(s1w.playerLives === s1.playerLives, `L1: lost lives walking right (${s1w.playerLives} < ${s1.playerLives})`);
   await game.screenshot('smoke-level-1-after-walk');
   console.log('Level 1 walk OK');
 
@@ -24,8 +29,9 @@ export default async function scenario(game) {
   await game.waitFrames(10);
 
   const s3 = await game.getState();
-  console.assert(s3.state === 'playing', `L3: expected playing, got ${s3.state}`);
-  console.assert(s3.levelNum === 2, `L3: expected levelNum 2, got ${s3.levelNum}`);
+  assert(s3.state === 'playing', `L3: expected playing, got ${s3.state}`);
+  assert(s3.levelNum === 2, `L3: expected levelNum 2, got ${s3.levelNum}`);
+  assert(s3.playerLives === 3, `L3: expected 3 lives, got ${s3.playerLives}`);
   await game.screenshot('smoke-level-3-initial');
   console.log('Level 3 initial state OK');
 


### PR DESCRIPTION
## Summary
- Adds `Ctrl+Shift+D` in-game debug overlay: player/enemy/item/bloom hitboxes, physics readout (position, velocity, onGround), FPS counter
- Adds `Ctrl+1–9` level warp shortcut (active in debug mode); preserves player lives/score across warps
- Exposes `window.trailBlazerDebug` API (`warpToLevel`, `screenshot`, `pressKey`, `releaseKey`, `getState`) loaded at `?debug=1` for Playwright automation
- Adds `qa/` directory with headless Playwright runner, `GameClient` wrapper, and a passing smoke scenario

## Test Plan
- [ ] Open `http://localhost:3000`, press `Ctrl+Shift+D` — overlay appears with hitboxes and HUD
- [ ] Press `Ctrl+3` while overlay is on — warps to level 3 (Bridge of the Gods)
- [ ] Press `Ctrl+Shift+D` again — overlay hides
- [ ] Open `http://localhost:3000?debug=1`, run `window.trailBlazerDebug.getState()` in DevTools console — returns game state object
- [ ] `cd qa && npm install && node runner.mjs scenarios/smoke.mjs` — all assertions pass, screenshots written to `qa/screenshots/`

closes #61