### PR TITLE
Merge water bottle into filter, tune water damage, improve trash pile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ python -m http.server 3000
 # then visit http://localhost:3000
 ```
 
-There are no tests, no linting tools, and no package.json. All verification is done by playing the game in a browser.
+There are no linting tools and no root-level package.json. The primary verification method is playing the game in a browser. For automated QA, see the `qa/` directory below.
 
 ## Architecture
 
@@ -45,7 +45,9 @@ The entire game is ~3785 lines of vanilla JavaScript in a single IIFE in `game.j
 | MAIN LOOP | 3374 | `update()` and `draw()` dispatch by `game.state`; `requestAnimationFrame` loop at ~60fps |
 | AUDIO | 3514 | Web Audio API synth — all sound effects generated procedurally, no audio files |
 | TOUCH CONTROLS | 3704 | Mobile button bindings |
-| BOOT | 3780 | `fetchLeaderboard()`, starts `requestAnimationFrame` loop |
+| DEBUG | ~3800 | `dbg` flag, `isDebug()`, `warpToLevel()`, FPS tracking, `drawDebugOverlay()`, keydown shortcuts |
+| DEBUG API | ~3885 | `window.trailBlazerDebug` — Playwright automation surface |
+| BOOT | ~3915 | `fetchLeaderboard()`, starts `requestAnimationFrame` loop |
 
 ### Game Loop
 
@@ -136,6 +138,62 @@ All work should follow this branch-based workflow:
    Any branches that were deleted on the remote but still exist locally (marked `[gone]`) can be bulk-removed with the `/clean_gone` skill.
 
 **Never commit directly to master.** Always work on a branch, even for small fixes.
+
+## Debug & Testing Tools
+
+### Human Debug Mode
+
+Press `Ctrl+Shift+D` in-game to toggle the debug overlay. It shows:
+- Colored hitbox outlines: player (red), enemies (orange), items (cyan), TP blooms (magenta)
+- Top-left HUD: game state, level, player tile/world position, vx/vy/onGround, enemy/item counts, FPS
+
+Press `Ctrl+1` through `Ctrl+9` (while overlay is on) to warp to any level. Lives and score are preserved across warps.
+
+> **Note:** `Ctrl+1–9` conflicts with browser tab-switching shortcuts in some browsers. Use `window.trailBlazerDebug.warpToLevel(n)` from DevTools as a reliable alternative.
+
+### Playwright Automated QA
+
+The `qa/` directory contains a headless Playwright runner for scripted testing.
+
+**Setup (once):**
+```bash
+cd qa
+npm install
+npx playwright install chromium
+```
+
+**Run a scenario:**
+```bash
+# Requires a local server: python -m http.server 3000
+cd qa
+node runner.mjs scenarios/smoke.mjs
+```
+
+**Write a new scenario** in `qa/scenarios/<name>.mjs`:
+```js
+export default async function scenario(game) {
+  await game.warpToLevel(2);        // warp to level 3 (0-indexed)
+  await game.waitFrames(30);        // wait ~30 frames
+  await game.holdKey('ArrowRight', 60); // hold right for 60 frames
+  await game.screenshot('my-shot'); // saves to qa/screenshots/my-shot.png
+  const s = await game.getState();  // { state, levelNum, levelTick, playerX, playerY,
+                                    //   playerLives, playerScore, enemyCount, itemCount }
+}
+```
+
+Screenshots are saved to `qa/screenshots/` (gitignored) and can be read with the `Read` tool for visual QA.
+
+### `window.trailBlazerDebug` API
+
+Available at `http://localhost:3000?debug=1` (or any time in the page):
+
+| Method | Description |
+|--------|-------------|
+| `warpToLevel(n)` | Warp to level index `n` (0–8); preserves lives/score |
+| `screenshot()` | Returns canvas as base64 PNG data URL |
+| `pressKey(code)` | Simulate keydown (e.g. `'ArrowRight'`) |
+| `releaseKey(code)` | Release simulated key |
+| `getState()` | Returns `{ state, levelNum, levelTick, playerX, playerY, playerLives, playerScore, enemyCount, itemCount }` |
 
 ## Firebase / Leaderboard
 

--- a/game.js
+++ b/game.js
@@ -136,7 +136,7 @@ const LEVELS = [
     spawnItems() {
       return [
         makeItem('bar', 8, 8), makeItem('spork', 43, 7),
-        makeItem('water', 55, 7), makeItem('filter', 66, 7),
+        makeItem('filter', 66, 7),
         makeItem('spray', 84, 5), makeItem('tent', 110, 6),
       ];
     },
@@ -202,7 +202,7 @@ const LEVELS = [
     spawnItems() {
       return [
         makeItem('bar', 15, 8), makeItem('spork', 52, 5),
-        makeItem('water', 68, 6), makeItem('filter', 80, 7),
+        makeItem('filter', 80, 7),
         makeItem('spray', 103, 4), makeItem('tent', 128, 5),
       ];
     },
@@ -275,7 +275,7 @@ const LEVELS = [
     spawnItems() {
       return [
         makeItem('bar', 10, 8), makeItem('spork', 44, 6),
-        makeItem('water', 58, 7), makeItem('filter', 73, 7),
+        makeItem('filter', 73, 7),
         makeItem('spray', 96, 6), makeItem('tent', 140, 5),
       ];
     },
@@ -354,7 +354,7 @@ const LEVELS = [
     spawnItems() {
       return [
         makeItem('bar', 9, 8), makeItem('spork', 60, 5),
-        makeItem('water', 72, 6), makeItem('filter', 85, 6),
+        makeItem('filter', 85, 6),
         makeItem('spray', 109, 5), makeItem('tent', 159, 5),
       ];
     },
@@ -430,7 +430,7 @@ const LEVELS = [
     spawnItems() {
       return [
         makeItem('bar', 12, 8), makeItem('spork', 65, 5),
-        makeItem('water', 78, 7), makeItem('filter', 90, 7),
+        makeItem('filter', 90, 7),
         makeItem('spray', 142, 5), makeItem('tent', 168, 5),
       ];
     },
@@ -514,7 +514,7 @@ const LEVELS = [
     spawnItems() {
       return [
         makeItem('bar', 15, 8), makeItem('spork', 61, 5),
-        makeItem('water', 80, 7), makeItem('filter', 97, 7),
+        makeItem('filter', 97, 7),
         makeItem('spray', 130, 4), makeItem('tent', 176, 6),
       ];
     },
@@ -603,7 +603,7 @@ const LEVELS = [
     spawnItems() {
       return [
         makeItem('bar', 18, 8), makeItem('spork', 68, 4),
-        makeItem('water', 85, 7), makeItem('filter', 103, 7),
+        makeItem('filter', 103, 7),
         makeItem('spray', 138, 5), makeItem('tent', 186, 4),
       ];
     },
@@ -695,7 +695,7 @@ const LEVELS = [
     spawnItems() {
       return [
         makeItem('bar', 20, 8), makeItem('spork', 65, 5),
-        makeItem('water', 82, 7), makeItem('filter', 100, 7),
+        makeItem('filter', 100, 7),
         makeItem('spray', 130, 5), makeItem('tent', 200, 5),
       ];
     },
@@ -790,7 +790,7 @@ const LEVELS = [
     spawnItems() {
       return [
         makeItem('bar', 18, 8), makeItem('spork', 64, 5),
-        makeItem('water', 80, 7), makeItem('filter', 97, 7),
+        makeItem('filter', 97, 7),
         makeItem('spray', 135, 4), makeItem('tent', 210, 4),
       ];
     },

--- a/game.js
+++ b/game.js
@@ -861,10 +861,9 @@ function drawParticles() {
 const ITEM_DEFS = {
   spork:  { label: 'Ti Spork',    pts: 100, color: '#C0C0C0', r: 8 },
   bar:    { label: 'Protein Bar', pts: 50,  color: '#D2691E', r: 8 },
-  filter: { label: 'Water Filter',pts: 200, color: '#4169E1', r: 9 },
+  filter: { label: 'Water Filter',pts: 200, color: '#4169E1', r: 9, heals: 1, healPts: 75 },
   tent:   { label: 'DCF Tent',    pts: 500, color: '#DAA520', r: 10 },
   spray:  { label: 'Bear Spray',  pts: 150, color: '#FF4500', r: 9 },
-  water:  { label: 'Water Bottle',pts: 25,  color: '#00BFFF', r: 9, heals: 1 },
 };
 
 function makeItem(type, tx, ty) {
@@ -1411,14 +1410,15 @@ function updatePlayer() {
     if (item.collected) return;
     if (aabb(player, { x: item.x, y: item.y, w: item.w, h: item.h })) {
       item.collected = true;
-      player.score += item.pts;
       const def = ITEM_DEFS[item.type];
       spawnParticles(item.x + 10, item.y + 10, def.color, 8, 3);
       if (def.heals && player.health < 3) {
         player.health = Math.min(3, player.health + def.heals);
+        player.score += def.healPts;
         audio.sfxHeal();
-        addFloatText(item.x + 10, item.y - 8, `${def.label} +1 H2O`, '#00BFFF');
+        addFloatText(item.x + 10, item.y - 8, `${def.label} +1\u2665`, '#00BFFF');
       } else {
+        player.score += item.pts;
         audio.sfxCollect();
         addFloatText(item.x + 10, item.y - 8, `${def.label} +${item.pts}`, '#ffff44');
       }

--- a/game.js
+++ b/game.js
@@ -1260,6 +1260,7 @@ function makePlayer() {
     sprayCooldown: 0,
     sprayTimer: 0,
     hurtTimer: 0,
+    waterDmgTimer: 0,
     frame: 0, frameTimer: 0,
     dead: false,
   };
@@ -1273,6 +1274,7 @@ function updatePlayer() {
   if (player.sprayCooldown > 0) player.sprayCooldown--;
   if (player.sprayTimer > 0) player.sprayTimer--;
   if (player.glissadeCooldown > 0) player.glissadeCooldown--;
+  if (player.waterDmgTimer > 0) player.waterDmgTimer--;
 
   // Horizontal movement
   let dx = 0;
@@ -1363,8 +1365,11 @@ function updatePlayer() {
   const cx = Math.floor((player.x + player.w / 2) / TS);
   const cy = Math.floor((player.y + player.h - 2) / TS);
   if (isWater(cx, cy) || isWater(cx, cy + 1)) {
-    audio.sfxWater();
-    hurtPlayer();
+    if (player.waterDmgTimer === 0) {
+      audio.sfxWater();
+      hurtPlayer();
+      player.waterDmgTimer = 180;
+    }
   }
 
   // Enemy collisions

--- a/game.js
+++ b/game.js
@@ -1494,6 +1494,7 @@ function hurtPlayer(instant) {
       player.vy = 0;
       player.health = 3;
       player.hurtTimer = 120;
+      player.waterDmgTimer = 0;
       cam.x = 0;
     }
   } else {

--- a/game.js
+++ b/game.js
@@ -2759,38 +2759,6 @@ function drawItemIcon(type, cx, cy) {
     ctx.lineTo(6, -12);
     ctx.lineTo(6, -8);
     ctx.stroke();
-
-  } else if (type === 'water') {
-    // Water bottle — clear plastic bottle with blue water
-    // Bottle body
-    ctx.fillStyle = 'rgba(180,220,255,0.6)';
-    roundRect(-5, -2, 10, 16, 3);
-    // Water fill inside
-    ctx.fillStyle = '#00AAEE';
-    roundRect(-4, 4, 8, 9, 2);
-    // Water highlight
-    ctx.fillStyle = '#44CCFF';
-    roundRect(-3, 5, 4, 7, 1);
-    // Bottle neck
-    ctx.fillStyle = 'rgba(180,220,255,0.6)';
-    ctx.fillRect(-3, -6, 6, 5);
-    // Cap
-    ctx.fillStyle = '#0088CC';
-    roundRect(-4, -9, 8, 4, 1);
-    // Cap highlight
-    ctx.fillStyle = '#00AAEE';
-    roundRect(-3, -8, 4, 2, 1);
-    // Shine on bottle
-    ctx.fillStyle = 'rgba(255,255,255,0.5)';
-    ctx.fillRect(-4, -1, 2, 14);
-    // Water drops (condensation)
-    ctx.fillStyle = 'rgba(100,200,255,0.7)';
-    ctx.beginPath();
-    ctx.arc(4, 2, 1, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.beginPath();
-    ctx.arc(3, 8, 0.8, 0, Math.PI * 2);
-    ctx.fill();
   }
 
   ctx.restore();

--- a/game.js
+++ b/game.js
@@ -1005,7 +1005,7 @@ function makeBeerCan(x, y, dir) {
 }
 
 function makeTrash(x, y) {
-  return { x: x - 6, y, w: 16, h: 8, variant: Math.floor(rnd(0, 3)) };
+  return { x: x - 16, y: y - 10, w: 32, h: 18 };
 }
 
 // ==================== FISH ====================
@@ -2508,31 +2508,69 @@ function drawTrashPiles() {
   trashPiles.forEach(t => {
     const sx = Math.round(t.x - cam.x);
     const sy = Math.round(t.y - cam.y);
-    if (sx < -20 || sx > W + 20) return;
+    if (sx < -40 || sx > W + 40) return;
     ctx.save();
     ctx.translate(sx, sy);
-    if (t.variant === 0) {
-      // Crushed beer can
-      ctx.fillStyle = '#A07808';
-      ctx.fillRect(2, 2, 10, 5);
-      ctx.fillStyle = '#C8960A';
-      ctx.fillRect(3, 3, 7, 3);
-    } else if (t.variant === 1) {
-      // Plastic wrapper
-      ctx.fillStyle = 'rgba(230,230,200,0.7)';
-      ctx.beginPath();
-      ctx.ellipse(8, 5, 7, 3, 0.3, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.strokeStyle = 'rgba(180,180,160,0.5)';
-      ctx.lineWidth = 1;
-      ctx.stroke();
-    } else {
-      // Candy wrapper
-      ctx.fillStyle = '#CC2222';
-      ctx.fillRect(1, 2, 13, 5);
-      ctx.fillStyle = '#FFCC00';
-      ctx.fillRect(4, 2, 6, 5);
-    }
+
+    // Ground shadow
+    ctx.fillStyle = 'rgba(0,0,0,0.15)';
+    ctx.beginPath();
+    ctx.ellipse(16, 17, 14, 3, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Crushed beer can (center, slightly angled) — most prominent piece
+    ctx.save();
+    ctx.translate(5, 4);
+    ctx.rotate(-0.15);
+    ctx.fillStyle = '#A07008';
+    ctx.fillRect(0, 0, 16, 8);       // can body (dark gold)
+    ctx.fillStyle = '#D4A010';
+    ctx.fillRect(1, 1, 12, 5);       // highlight face
+    ctx.fillStyle = '#888';
+    ctx.fillRect(0, 0, 2, 8);        // left end cap
+    ctx.fillRect(14, 0, 2, 8);       // right end cap
+    ctx.fillStyle = '#7A5806';
+    ctx.fillRect(5, 2, 4, 4);        // crush dent
+    ctx.restore();
+
+    // Crumpled plastic bag (right side) — translucent white blob
+    ctx.fillStyle = 'rgba(215,215,195,0.65)';
+    ctx.beginPath();
+    ctx.moveTo(21, 3);
+    ctx.lineTo(30, 5);
+    ctx.lineTo(31, 13);
+    ctx.lineTo(22, 14);
+    ctx.lineTo(20, 8);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(160,160,140,0.5)';
+    ctx.lineWidth = 0.8;
+    ctx.stroke();
+
+    // Bottle cap (top right, gray ridged disc)
+    ctx.fillStyle = '#777';
+    ctx.beginPath();
+    ctx.arc(28, 2, 3.5, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#999';
+    ctx.beginPath();
+    ctx.arc(28, 2, 2, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Candy wrapper (bottom left, red/yellow)
+    ctx.fillStyle = '#CC2020';
+    ctx.fillRect(1, 12, 9, 5);
+    ctx.fillStyle = '#FFCC00';
+    ctx.fillRect(3, 12, 5, 5);
+    ctx.fillStyle = '#AA1010';
+    ctx.fillRect(1, 12, 2, 5);       // left twisted end
+
+    // Cigarette butt (bottom center)
+    ctx.fillStyle = '#DDD';
+    ctx.fillRect(14, 15, 6, 2);
+    ctx.fillStyle = '#D06040';
+    ctx.fillRect(14, 15, 2, 2);      // burnt orange tip
+
     ctx.restore();
   });
 }


### PR DESCRIPTION
## Summary
- **#57** — Water bottle item removed; filter now heals 1 health for 75pts when player is injured, or awards full 200pts when health is full
- **#60** — Water damage throttled to one hit per 3 seconds (180 frames) via independent `waterDmgTimer`, down from 1.5s; no longer an almost-certain death sentence
- **#58** — Redneck trash pile redrawn at 32×18px with assorted litter: crushed beer can, crumpled plastic bag, bottle cap, candy wrapper, cigarette butt

## Test Plan
- [ ] Level 1: only one water-related collectible (the filter) appears — no water bottle
- [ ] Pick up filter at full health → float text shows `Water Filter +200`
- [ ] Take a hit, then pick up filter → float text shows `Water Filter +1♥`, score +75
- [ ] Walk into water and time the hits — approximately 3 seconds between each
- [ ] Kill a redneck — trash pile should be clearly readable as assorted litter

closes #57
closes #60
closes #58