### PR TITLE
fix: align trail runner feet with background ground line

### DIFF
--- a/game.js
+++ b/game.js
@@ -1835,7 +1835,7 @@ function drawBackground() {
 }
 
 function drawTrailRunners() {
-  const runnerBase = H * 0.53 + 2; // just at the tree line base
+  const runnerBase = H * 0.53 + 5; // feet land at tree trunk base (treeBase + 10)
   trailRunners.forEach(r => {
     const sx = r.x - cam.x * 0.35; // parallax slightly in front of trees (0.30)
     if (sx < -30 || sx > W + 30) return;


### PR DESCRIPTION
Move runnerBase from H*0.53+2 to H*0.53+5 so that runner feet land at the base of the background pine tree trunks (the implied parallax ground level), eliminating the visual float.

Closes #73

Generated with [Claude Code](https://claude.ai/code)