### PR TITLE
fix: microbear hitbox and mobile action button size (#81, #80)

### DIFF
--- a/docs/superpowers/plans/2026-04-10-microbear-hitbox-mobile-buttons.md
+++ b/docs/superpowers/plans/2026-04-10-microbear-hitbox-mobile-buttons.md
@@ -1,0 +1,240 @@
+# Microbear Hitbox & Mobile Action Buttons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the Micro Bear hitbox so stomping is reliable (#81) and enlarge the mobile landscape action buttons for better playability (#80).
+
+**Architecture:** Two independent single-file edits. Task 1 changes one factory function in `game.js`. Task 2 changes two CSS values in `style.css`. Neither depends on the other — they can be committed separately.
+
+**Tech Stack:** Vanilla JS, Canvas 2D, CSS. No build step. Verify via browser at `http://localhost:3000` (requires `python -m http.server 3000`) and Playwright QA runner (`cd qa && node runner.mjs scenarios/<name>.mjs`).
+
+---
+
+## Files Modified
+
+- `game.js` — `makeMouse` factory (~line 954)
+- `style.css` — landscape `@media` block, `#touch-right` override (~line 178)
+
+---
+
+### Task 1: Enlarge Micro Bear hitbox (issue #81)
+
+**Files:**
+- Modify: `game.js:954-967` (`makeMouse`)
+
+**Context:** `makeMouse` at ~line 954 returns `w: 16, h: 12`. The stomp check is `player.y + player.h < e.y + e.h * 0.75`, giving a 9px-tall stomp zone on a 12px hitbox. Increasing to `w: 22, h: 18` widens the stomp zone to 13.5px and gives a 22px-wide landing surface. `drawMouse` draws from `(sx + e.w/2, sy + e.h)` (bottom-center) so the visual stays correct at any hitbox size — no draw changes needed. The debug overlay (`Ctrl+Shift+D`) shows hitboxes in orange for visual confirmation.
+
+- [ ] **Step 1: Update `makeMouse` in `game.js`**
+
+Find the `makeMouse` function (~line 954). Change `w` and `h`:
+
+**Before:**
+```js
+function makeMouse(tx, ty) {
+  return {
+    type: 'mouse',
+    x: tx * TS, y: ty * TS + 8,
+    w: 16, h: 12,
+```
+
+**After:**
+```js
+function makeMouse(tx, ty) {
+  return {
+    type: 'mouse',
+    x: tx * TS, y: ty * TS + 8,
+    w: 22, h: 18,
+```
+
+- [ ] **Step 2: Write a Playwright QA scenario**
+
+Create `qa/scenarios/microbear-hitbox.mjs`:
+
+```js
+// Visual QA: confirm Micro Bear hitbox is larger than before.
+// The runner loads /?debug=1 so dbg.url=true and the debug overlay
+// (orange hitbox outlines) is already active — no extra setup needed.
+// Warps to level 3 (first level with Micro Bears) and screenshots.
+
+export default async function scenario(game) {
+  await game.warpToLevel(2);
+  await game.waitFrames(20);
+
+  // Walk right so Micro Bears are visible on screen
+  await game.holdKey('ArrowRight', 40);
+  await game.waitFrames(10);
+  await game.screenshot('microbear-hitbox-debug');
+  console.log('Screenshot saved to qa/screenshots/microbear-hitbox-debug.png');
+  console.log('Inspect: orange enemy hitboxes should show ~22x18 for Micro Bears');
+}
+```
+
+- [ ] **Step 3: Start the local server (if not already running)**
+
+```bash
+python -m http.server 3000
+```
+
+Keep this running in a separate terminal for all verification steps.
+
+- [ ] **Step 4: Run the QA scenario**
+
+```bash
+cd qa
+node runner.mjs scenarios/microbear-hitbox.mjs
+```
+
+Expected output:
+```
+Screenshot saved to qa/screenshots/microbear-hitbox-debug.png
+Inspect: orange enemy hitboxes should show ~22x18 for Micro Bears
+```
+
+- [ ] **Step 5: Inspect the screenshot**
+
+Read `qa/screenshots/microbear-hitbox-debug.png`. Confirm:
+- Orange hitbox outline on Micro Bears is visibly wider/taller than the marmot (26×22) is taller but similar in width — the mouse box should be clearly larger than before (was 16×12)
+- No visual gap between the hitbox outline and the drawn mouse body
+- Mouse body still looks correct (body/head/ears aligned to bottom-center of box)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add game.js qa/scenarios/microbear-hitbox.mjs
+git commit -m "fix: enlarge Micro Bear hitbox to 22x18 for easier stomping (#81)
+
+Stomp zone increases from 9px to 13.5px tall and width from 16px
+to 22px. drawMouse anchors from bottom-center so visual is unchanged.
+
+closes #81"
+```
+
+---
+
+### Task 2: Increase mobile landscape action button size (issue #80)
+
+**Files:**
+- Modify: `style.css:178-185` (`#touch-right` in landscape `@media` block)
+
+**Context:** The landscape `@media (hover: none) and (pointer: coarse) and (orientation: landscape)` block at ~line 157 overrides `#touch-right` dimensions. The current values are `width: clamp(115px, 21vw, 165px)` and `height: clamp(70px, 13vw, 100px)`. These need to increase ~25% to `clamp(140px, 26vw, 200px)` and `clamp(90px, 17vw, 130px)` respectively. The buttons (SLIDE, SPRAY, JUMP) fill the panel via `flex: 1` / `align-items: stretch`, so both rows scale automatically.
+
+- [ ] **Step 1: Update `#touch-right` in `style.css`**
+
+Find the `#touch-right` block inside the landscape `@media` query (~line 178):
+
+**Before:**
+```css
+  #touch-right {
+    position: fixed;
+    bottom: 8px;
+    right: 8px;
+    width: clamp(115px, 21vw, 165px);
+    height: clamp(70px, 13vw, 100px);
+    gap: 3px;
+  }
+```
+
+**After:**
+```css
+  #touch-right {
+    position: fixed;
+    bottom: 8px;
+    right: 8px;
+    width: clamp(140px, 26vw, 200px);
+    height: clamp(90px, 17vw, 130px);
+    gap: 3px;
+  }
+```
+
+- [ ] **Step 2: Write a Playwright QA scenario**
+
+Create `qa/scenarios/mobile-buttons.mjs`:
+
+```js
+// Visual QA: screenshot the full page to evaluate mobile action button sizing.
+// The CSS media query requires `pointer: coarse` which Playwright doesn't set
+// by default, so we inject a style override to force the landscape touch layout.
+// We use page.screenshot() (not the canvas API) to capture the full page DOM
+// including the touch-controls overlay.
+
+import { writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default async function scenario(game) {
+  await game.page.setViewportSize({ width: 844, height: 390 });
+  await game.warpToLevel(0);
+  await game.waitFrames(10);
+
+  // Force the landscape touch controls visible by overriding display and applying
+  // the landscape positioning directly — bypasses the pointer:coarse media query.
+  await game.page.evaluate(() => {
+    const tc = document.getElementById('touch-controls');
+    const tl = document.getElementById('touch-left');
+    const tr = document.getElementById('touch-right');
+
+    // Mirror the landscape @media overrides from style.css
+    Object.assign(tc.style, {
+      display: 'flex', position: 'fixed', bottom: '0', left: '0', right: '0',
+      height: 'auto', padding: '0', gap: '0', justifyContent: 'space-between',
+      zIndex: '10', background: 'none', pointerEvents: 'none',
+    });
+    Object.assign(tl.style, {
+      position: 'fixed', bottom: '8px', left: '8px',
+      width: 'clamp(108px, 21.6vw, 168px)', height: 'clamp(53px, 10.8vw, 78px)', gap: '4px',
+    });
+    Object.assign(tr.style, {
+      position: 'fixed', bottom: '8px', right: '8px', gap: '3px',
+      // These are the NEW values — the ones being tested:
+      width: 'clamp(140px, 26vw, 200px)', height: 'clamp(90px, 17vw, 130px)',
+    });
+  });
+
+  // Use Playwright's full-page screenshot to capture DOM elements (canvas + buttons)
+  const buf = await game.page.screenshot({ fullPage: false });
+  const outPath = resolve(__dirname, '..', 'screenshots', 'mobile-buttons-landscape.png');
+  writeFileSync(outPath, buf);
+  console.log('Screenshot saved to qa/screenshots/mobile-buttons-landscape.png');
+  console.log('Inspect: SLIDE/SPRAY/JUMP buttons bottom-right, arrow buttons bottom-left.');
+  console.log('Right panel should be visibly larger than left. No overflow.');
+}
+```
+
+- [ ] **Step 3: Run the QA scenario**
+
+```bash
+cd qa
+node runner.mjs scenarios/mobile-buttons.mjs
+```
+
+Expected output:
+```
+Screenshot saved to qa/screenshots/mobile-buttons-landscape.png
+Inspect: right-side buttons (SLIDE/SPRAY/JUMP) should be clearly tappable,
+proportional to the left-side arrow buttons.
+```
+
+- [ ] **Step 4: Inspect the screenshot**
+
+Read `qa/screenshots/mobile-buttons-landscape.png`. Confirm:
+- SLIDE, SPRAY, and JUMP buttons are visible in the bottom-right corner
+- The right-side panel is visibly larger than the left-side directional buttons (by design — more actions need more real estate)
+- Buttons do not overflow off the right or bottom edge of the screen
+- The panel looks proportional — not so large it obscures gameplay area
+
+If the buttons look too small or too large, adjust the clamp values in `style.css` and re-run the scenario.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add style.css qa/scenarios/mobile-buttons.mjs
+git commit -m "feat: increase mobile landscape action button size (#80)
+
+#touch-right panel width clamp(115→140px, 21→26vw, 165→200px),
+height clamp(70→90px, 13→17vw, 100→130px). SLIDE/SPRAY/JUMP
+buttons scale via flex stretch — no per-button changes needed.
+
+closes #80"
+```

--- a/docs/superpowers/specs/2026-04-10-microbear-hitbox-mobile-buttons-design.md
+++ b/docs/superpowers/specs/2026-04-10-microbear-hitbox-mobile-buttons-design.md
@@ -1,0 +1,65 @@
+# Microbear Hitbox & Mobile Action Button Size — Design
+
+**Issues:** #81 (microbear hitbox too small), #80 (mobile landscape action buttons too small)
+
+**Date:** 2026-04-10
+
+---
+
+## Issue #81 — Microbear Hitbox
+
+### Problem
+
+The Micro Bear (`type: 'mouse'`) has a hitbox of `w: 16, h: 12` — the smallest of any enemy. The stomp condition is:
+
+```js
+const stomping = prevVy > 0 && player.y + player.h < e.y + e.h * 0.75;
+```
+
+This gives a stomp zone of only 9px tall × 16px wide. Because the Micro Bear also moves at `vx: 1.8` (fastest ground enemy), players frequently land next to it rather than on top, triggering unexpected damage instead of a stomp.
+
+### Design
+
+Enlarge the hitbox in `makeMouse`:
+
+| Field | Before | After |
+|-------|--------|-------|
+| `w`   | 16     | 22    |
+| `h`   | 12     | 18    |
+
+**Why this works without changing the drawing:** `drawMouse` anchors from `(sx + e.w/2, sy + e.h)` — the bottom-center of the hitbox. All body/head/ear coordinates are offsets from there, so they remain visually correct at any hitbox size. The visual occupies approximately the bottom 12px of the new 18px hitbox, leaving ~6px of clear "landing zone" at the top that counts as a stomp.
+
+**New stomp zone:** 0.75 × 18 = 13.5px from top — compared to 9px before. Width increases from 16 to 22px. No changes to stomp logic, draw code, or other enemy types.
+
+**Spawn y:** `ty * TS + 8` — unchanged. Physics settles the enemy on the ground regardless of initial offset.
+
+### Files
+
+- `game.js` — `makeMouse` factory only (~line 954)
+
+---
+
+## Issue #80 — Mobile Landscape Action Buttons
+
+### Problem
+
+The right-side touch control panel (`#touch-right`) holds three action buttons: SLIDE, SPRAY (top row), and JUMP (full bottom row). The current landscape override sizes these at `clamp(115px, 21vw, 165px)` wide × `clamp(70px, 13vw, 100px)` tall — noticeably smaller and harder to tap reliably than they should be.
+
+### Design
+
+Increase `#touch-right` dimensions in the landscape `@media` block by ~25%:
+
+| Property | Before | After |
+|----------|--------|-------|
+| `width`  | `clamp(115px, 21vw, 165px)` | `clamp(140px, 26vw, 200px)` |
+| `height` | `clamp(70px, 13vw, 100px)`  | `clamp(90px, 17vw, 130px)`  |
+
+At a 390px-wide landscape viewport (e.g., iPhone 14): new width = min(200, 26% × 390) = 101px → hits 140px min. New height = min(130, 17% × 390) = 66px → hits 90px min. On a wider tablet landscape (1024px): width = min(200, 267) = 200px, height = min(130, 174) = 130px.
+
+The buttons fill the panel via `flex: 1` / `align-items: stretch`, so all three scale together automatically. No per-button CSS changes needed.
+
+**Verification:** After coding, take a QA screenshot and evaluate proportionality against the left-side directional buttons.
+
+### Files
+
+- `style.css` — landscape `@media` block, `#touch-right` override (~line 178)

--- a/game.js
+++ b/game.js
@@ -955,7 +955,7 @@ function makeMouse(tx, ty) {
   return {
     type: 'mouse',
     x: tx * TS, y: ty * TS + 8,
-    w: 16, h: 12,
+    w: 22, h: 18,
     vx: -1.8, vy: 0,
     onGround: false,
     alive: true,

--- a/qa/scenarios/microbear-hitbox.mjs
+++ b/qa/scenarios/microbear-hitbox.mjs
@@ -1,0 +1,16 @@
+// Visual QA: confirm Micro Bear hitbox is larger than before.
+// The runner loads /?debug=1 so dbg.url=true and the debug overlay
+// (orange hitbox outlines) is already active — no extra setup needed.
+// Warps to level 3 (first level with Micro Bears) and screenshots.
+
+export default async function scenario(game) {
+  await game.warpToLevel(2);
+  await game.waitFrames(20);
+
+  // Walk right so Micro Bears are visible on screen
+  await game.holdKey('ArrowRight', 40);
+  await game.waitFrames(10);
+  await game.screenshot('microbear-hitbox-debug');
+  console.log('Screenshot saved to qa/screenshots/microbear-hitbox-debug.png');
+  console.log('Inspect: orange enemy hitboxes should show ~22x18 for Micro Bears');
+}

--- a/qa/scenarios/mobile-buttons.mjs
+++ b/qa/scenarios/mobile-buttons.mjs
@@ -1,0 +1,49 @@
+// Visual QA: screenshot the full page to evaluate mobile action button sizing.
+// The CSS media query requires `pointer: coarse` which Playwright doesn't set
+// by default, so we inject a style override to force the landscape touch layout.
+// We use page.screenshot() (not the canvas API) to capture the full page DOM
+// including the touch-controls overlay.
+
+import { writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default async function scenario(game) {
+  await game.page.setViewportSize({ width: 844, height: 390 });
+  await game.warpToLevel(0);
+  await game.waitFrames(10);
+
+  // Force the landscape touch controls visible by overriding display and applying
+  // the landscape positioning directly — bypasses the pointer:coarse media query.
+  await game.page.evaluate(() => {
+    const tc = document.getElementById('touch-controls');
+    const tl = document.getElementById('touch-left');
+    const tr = document.getElementById('touch-right');
+
+    // Mirror the landscape @media overrides from style.css
+    Object.assign(tc.style, {
+      display: 'flex', position: 'fixed', bottom: '0', left: '0', right: '0',
+      height: 'auto', padding: '0', gap: '0', justifyContent: 'space-between',
+      zIndex: '10', background: 'none', pointerEvents: 'none',
+    });
+    Object.assign(tl.style, {
+      position: 'fixed', bottom: '8px', left: '8px',
+      width: 'clamp(108px, 21.6vw, 168px)', height: 'clamp(53px, 10.8vw, 78px)', gap: '4px',
+    });
+    Object.assign(tr.style, {
+      position: 'fixed', bottom: '8px', right: '8px', gap: '3px',
+      // These are the NEW values — the ones being tested:
+      width: 'clamp(140px, 26vw, 200px)', height: 'clamp(90px, 17vw, 130px)',
+    });
+  });
+
+  // Use Playwright's full-page screenshot to capture DOM elements (canvas + buttons)
+  const buf = await game.page.screenshot({ fullPage: false });
+  const outPath = resolve(__dirname, '..', 'screenshots', 'mobile-buttons-landscape.png');
+  writeFileSync(outPath, buf);
+  console.log('Screenshot saved to qa/screenshots/mobile-buttons-landscape.png');
+  console.log('Inspect: SLIDE/SPRAY/JUMP buttons bottom-right, arrow buttons bottom-left.');
+  console.log('Right panel should be visibly larger than left. No overflow.');
+}

--- a/style.css
+++ b/style.css
@@ -179,8 +179,8 @@ canvas {
     position: fixed;
     bottom: 8px;
     right: 8px;
-    width: clamp(115px, 21vw, 165px);
-    height: clamp(70px, 13vw, 100px);
+    width: clamp(140px, 26vw, 200px);
+    height: clamp(90px, 17vw, 130px);
     gap: 3px;
   }
   .touch-btn {


### PR DESCRIPTION
## Summary
- Enlarged Micro Bear hitbox from 16×12 to 22×18 so stomping is more reliable — stomp zone grows from 9px to 13.5px tall, width from 16px to 22px wide (#81)
- Increased mobile landscape action button panel ~25%: width `clamp(115→140px, 21→26vw, 165→200px)`, height `clamp(70→90px, 13→17vw, 100→130px)` (#80)
- Added QA scenarios for both changes (`qa/scenarios/microbear-hitbox.mjs`, `qa/scenarios/mobile-buttons.mjs`)

## Test Plan
- [ ] Warp to level 3, confirm Micro Bears are easier to stomp — landing near their head shouldn't miss the stun zone
- [ ] Run `cd qa && node runner.mjs scenarios/microbear-hitbox.mjs` — inspect orange hitbox outline in screenshot
- [ ] On a mobile device in landscape, confirm SLIDE/SPRAY/JUMP buttons are noticeably larger and easier to tap
- [ ] Run `cd qa && node runner.mjs scenarios/mobile-buttons.mjs` — inspect button proportions in screenshot

closes #81
closes #80