### PR TITLE
qa: add mobile device emulation to Playwright runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,10 +167,25 @@ npx playwright install chromium
 # Requires a local server: python -m http.server 3000
 cd qa
 node runner.mjs scenarios/smoke.mjs
+# Emulate a mobile device (landscape touch UI, etc.):
+node runner.mjs --device=mobile-landscape scenarios/mobile-buttons.mjs
 ```
+
+**Device presets** live in `qa/lib/devices.mjs`:
+
+| Preset | Viewport | `hasTouch` / `isMobile` | Notes |
+|---|---|---|---|
+| `desktop` (default) | 1280x720 | false | Default for all existing scenarios. |
+| `mobile-portrait` | 393x727 | true | Pixel-5-ish portrait; `(orientation: portrait)` matches. |
+| `mobile-landscape` | 844x390 | true | Pixel-5-ish landscape; activates the full-screen touch overlay. |
+
+The mobile presets set `hasTouch` + `isMobile` so the game's `(hover: none) and (pointer: coarse)` media query matches naturally — no CSS injection needed to see the touch controls.
 
 **Write a new scenario** in `qa/scenarios/<name>.mjs`:
 ```js
+// Optional: pick a device preset. The CLI `--device=<name>` flag overrides this.
+export const options = { device: 'mobile-landscape' };
+
 export default async function scenario(game) {
   await game.warpToLevel(2);        // warp to level 3 (0-indexed)
   await game.waitFrames(30);        // wait ~30 frames

--- a/qa/lib/devices.mjs
+++ b/qa/lib/devices.mjs
@@ -1,0 +1,58 @@
+// Device presets for Playwright browser contexts.
+//
+// Why this exists: the game's mobile UI (touch buttons, full-screen landscape
+// canvas) is gated on the CSS media query `(hover: none) and (pointer: coarse)`,
+// which a default Playwright page does NOT match — Chromium reports hover:hover
+// and pointer:fine unless the context is created with `hasTouch` + `isMobile`.
+//
+// Each preset is spread directly into `browser.newContext()`. The keys mirror
+// Playwright's own `devices[...]` shape so presets stay swappable with the
+// built-in list (e.g. `devices['Pixel 5 landscape']`).
+//
+// `desktop` is the default and intentionally leaves `hasTouch`/`isMobile` off
+// so existing scenarios keep behaving exactly as before.
+
+export const DEVICE_PRESETS = {
+  desktop: {
+    viewport: { width: 1280, height: 720 },
+    deviceScaleFactor: 1,
+    isMobile: false,
+    hasTouch: false,
+  },
+
+  // Pixel-5-ish portrait: narrow viewport, touch + mobile UA so the game's
+  // `(hover: none) and (pointer: coarse)` media query matches.
+  'mobile-portrait': {
+    viewport: { width: 393, height: 727 },
+    deviceScaleFactor: 2.75,
+    isMobile: true,
+    hasTouch: true,
+    userAgent:
+      'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 ' +
+      '(KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+  },
+
+  // Pixel-5-ish landscape: wide viewport so `(orientation: landscape)` matches
+  // and the game's landscape touch overlay activates.
+  'mobile-landscape': {
+    viewport: { width: 844, height: 390 },
+    deviceScaleFactor: 2.75,
+    isMobile: true,
+    hasTouch: true,
+    userAgent:
+      'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 ' +
+      '(KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+  },
+};
+
+export const DEFAULT_DEVICE = 'desktop';
+
+export function resolveDevice(name) {
+  const key = name || DEFAULT_DEVICE;
+  const preset = DEVICE_PRESETS[key];
+  if (!preset) {
+    const available = Object.keys(DEVICE_PRESETS).join(', ');
+    throw new Error(`Unknown device preset "${key}". Available: ${available}`);
+  }
+  return preset;
+}

--- a/qa/runner.mjs
+++ b/qa/runner.mjs
@@ -2,20 +2,43 @@ import { chromium } from 'playwright';
 import { resolve, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { GameClient } from './lib/game-client.mjs';
+import { DEFAULT_DEVICE, resolveDevice } from './lib/devices.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const scenarioArg = process.argv[2];
+// Parse CLI args: first positional is the scenario path; `--device=<name>`
+// picks a device preset from qa/lib/devices.mjs. The device flag overrides
+// whatever the scenario exports via `options.device`.
+let scenarioArg;
+let deviceOverride;
+for (const arg of process.argv.slice(2)) {
+  if (arg.startsWith('--device=')) {
+    deviceOverride = arg.slice('--device='.length);
+  } else if (!scenarioArg) {
+    scenarioArg = arg;
+  }
+}
+
 if (!scenarioArg) {
-  console.error('Usage: node runner.mjs scenarios/<name>.mjs');
+  console.error('Usage: node runner.mjs [--device=<name>] scenarios/<name>.mjs');
+  console.error('Devices: desktop (default), mobile-portrait, mobile-landscape');
   process.exit(1);
 }
+
+const scenarioPath = resolve(__dirname, scenarioArg);
+const { default: scenario, options: scenarioOptions } = await import(
+  pathToFileURL(scenarioPath).href
+);
+
+const deviceName = deviceOverride || scenarioOptions?.device || DEFAULT_DEVICE;
+const devicePreset = resolveDevice(deviceName);
 
 let browser;
 let exitCode = 0;
 try {
   browser = await chromium.launch({ headless: true });
-  const page = await browser.newPage();
+  const context = await browser.newContext(devicePreset);
+  const page = await context.newPage();
 
   await page.goto('http://localhost:3000?debug=1');
   await page.waitForFunction(
@@ -23,9 +46,8 @@ try {
     { timeout: 10000 }
   );
 
-  const scenarioPath = resolve(__dirname, scenarioArg);
-  const { default: scenario } = await import(pathToFileURL(scenarioPath).href);
   const client = new GameClient(page);
+  console.log(`Running scenario with device preset: ${deviceName}`);
 
   await scenario(client);
   console.log('Scenario completed successfully.');

--- a/qa/scenarios/mobile-buttons.mjs
+++ b/qa/scenarios/mobile-buttons.mjs
@@ -1,8 +1,12 @@
-// Visual QA: screenshot the full page to evaluate mobile action button sizing.
-// The CSS media query requires `pointer: coarse` which Playwright doesn't set
-// by default, so we inject a style override to force the landscape touch layout.
-// We use page.screenshot() (not the canvas API) to capture the full page DOM
-// including the touch-controls overlay.
+// Visual QA: screenshot the full page to evaluate mobile action button sizing
+// in landscape orientation.
+//
+// This scenario opts into the runner's `mobile-landscape` device preset via
+// the `options` export below. That gives the page context `hasTouch: true`
+// and `isMobile: true`, so the game's `(hover: none) and (pointer: coarse)`
+// media query matches naturally — no CSS injection needed. The viewport
+// dimensions make `(orientation: landscape)` match, activating the landscape
+// touch overlay from style.css.
 
 import { writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
@@ -10,34 +14,11 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+export const options = { device: 'mobile-landscape' };
+
 export default async function scenario(game) {
-  await game.page.setViewportSize({ width: 844, height: 390 });
   await game.warpToLevel(0);
   await game.waitFrames(10);
-
-  // Force the landscape touch controls visible by overriding display and applying
-  // the landscape positioning directly — bypasses the pointer:coarse media query.
-  await game.page.evaluate(() => {
-    const tc = document.getElementById('touch-controls');
-    const tl = document.getElementById('touch-left');
-    const tr = document.getElementById('touch-right');
-
-    // Mirror the landscape @media overrides from style.css
-    Object.assign(tc.style, {
-      display: 'flex', position: 'fixed', bottom: '0', left: '0', right: '0',
-      height: 'auto', padding: '0', gap: '0', justifyContent: 'space-between',
-      zIndex: '10', background: 'none', pointerEvents: 'none',
-    });
-    Object.assign(tl.style, {
-      position: 'fixed', bottom: '8px', left: '8px',
-      width: 'clamp(108px, 21.6vw, 168px)', height: 'clamp(53px, 10.8vw, 78px)', gap: '4px',
-    });
-    Object.assign(tr.style, {
-      position: 'fixed', bottom: '8px', right: '8px', gap: '3px',
-      // These are the NEW values — the ones being tested:
-      width: 'clamp(140px, 26vw, 200px)', height: 'clamp(90px, 17vw, 130px)',
-    });
-  });
 
   // Use Playwright's full-page screenshot to capture DOM elements (canvas + buttons)
   const buf = await game.page.screenshot({ fullPage: false });

--- a/qa/scenarios/mobile-portrait.mjs
+++ b/qa/scenarios/mobile-portrait.mjs
@@ -1,0 +1,51 @@
+// Visual QA: confirm the mobile-portrait device preset activates the touch UI.
+//
+// On portrait mobile, style.css shows the `#touch-controls` block via the
+// `(hover: none) and (pointer: coarse)` media query (without the landscape
+// overrides). This scenario verifies: (1) the runner preset wires that up
+// without any per-scenario CSS hacks, (2) the controls are actually visible,
+// and (3) the media-query signals the game cares about are all reporting
+// the expected values.
+
+import { writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(`Assertion failed: ${msg}`);
+}
+
+export const options = { device: 'mobile-portrait' };
+
+export default async function scenario(game) {
+  await game.warpToLevel(0);
+  await game.waitFrames(10);
+
+  const probe = await game.page.evaluate(() => {
+    const tc = document.getElementById('touch-controls');
+    return {
+      hoverNone: matchMedia('(hover: none)').matches,
+      pointerCoarse: matchMedia('(pointer: coarse)').matches,
+      portrait: matchMedia('(orientation: portrait)').matches,
+      touchDisplay: tc ? getComputedStyle(tc).display : 'missing',
+      innerW: window.innerWidth,
+      innerH: window.innerHeight,
+    };
+  });
+
+  assert(probe.hoverNone, `expected (hover: none) to match, got ${probe.hoverNone}`);
+  assert(probe.pointerCoarse, `expected (pointer: coarse) to match, got ${probe.pointerCoarse}`);
+  assert(probe.portrait, `expected portrait orientation (got ${probe.innerW}x${probe.innerH})`);
+  assert(
+    probe.touchDisplay === 'flex',
+    `expected #touch-controls display:flex, got "${probe.touchDisplay}"`
+  );
+
+  const buf = await game.page.screenshot({ fullPage: false });
+  const outPath = resolve(__dirname, '..', 'screenshots', 'mobile-buttons-portrait.png');
+  writeFileSync(outPath, buf);
+  console.log('Screenshot saved to qa/screenshots/mobile-buttons-portrait.png');
+  console.log('Inspect: touch controls docked along the bottom, no landscape overlay.');
+}


### PR DESCRIPTION
## Summary

closes #83

The QA runner previously created a vanilla Chromium page via `browser.newPage()`. That context reports `hover: hover` and `pointer: fine`, so the game's `(hover: none) and (pointer: coarse)` media query never matched — the `#touch-controls` element stayed `display: none`, and screenshots like the one attached to #83 showed no mobile buttons. The `mobile-buttons.mjs` scenario worked around this by hand-injecting CSS via `page.evaluate`, which is exactly what #83 asked us to fix.

### What changed

- **`qa/lib/devices.mjs` (new)** — preset map with `desktop` (default), `mobile-portrait` (393x727), and `mobile-landscape` (844x390). Mobile presets set `hasTouch: true`, `isMobile: true`, a Pixel-5 user agent, and `deviceScaleFactor: 2.75`, so both `(hover: none)` and `(pointer: coarse)` match in Chromium.
- **`qa/runner.mjs`** — parses a `--device=<name>` CLI flag, reads an optional `options.device` export from the scenario, resolves a preset, and creates the page via `browser.newContext(preset).newPage()` so Playwright's emulation drives the media-query state.
- **`qa/scenarios/mobile-buttons.mjs`** — now opts into `mobile-landscape` via `export const options` and drops the entire CSS-injection block; behavior is identical but it's testing the real media-query path.
- **`qa/scenarios/mobile-portrait.mjs` (new)** — opts into `mobile-portrait`, asserts that `(hover: none)`, `(pointer: coarse)`, and `(orientation: portrait)` all match and `#touch-controls` computes to `display: flex`. Acts as a regression test for the preset wiring and demonstrates the portrait orientation, which #83 explicitly called out.
- **`CLAUDE.md`** — documents the new presets, the `--device` flag, and the `options` scenario export.

Existing `smoke.mjs` and `microbear-hitbox.mjs` scenarios are untouched and inherit the `desktop` default, so they behave exactly as before.

### Test plan

- [x] `node --check` on all modified/new `.mjs` files
- [x] `resolveDevice()` smoke-test: all three presets return the expected shape, unknown names raise a clear error
- [x] `node runner.mjs` with no args prints updated usage (lists presets), exits 1
- [x] `node runner.mjs --device=bogus scenarios/smoke.mjs` rejects with the available list, exits 1
- [x] Local `python3 -m http.server 3000` serves `index.html`, `game.js`, and `style.css` (200 OK); `node --check game.js` still passes (unchanged file)
- [ ] Full Playwright scenario run — **could not execute in this sandbox**: `npx playwright install chromium` fails with `403 Host not allowed` on `cdn.playwright.dev`. Please run locally after merging:
  ```bash
  cd qa
  node runner.mjs --device=mobile-landscape scenarios/mobile-buttons.mjs
  node runner.mjs scenarios/mobile-portrait.mjs
  node runner.mjs scenarios/smoke.mjs          # desktop default still works
  ```
  Expected: `qa/screenshots/mobile-buttons-landscape.png` shows the real touch overlay driven by CSS (not injected styles), and `mobile-portrait.mjs` passes all four media-query assertions before saving `mobile-buttons-portrait.png`.